### PR TITLE
Remove old instance_ufo output before writing

### DIFF
--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -777,8 +777,7 @@ def write_ufo(ufo, out_dir):
     out_path = build_ufo_path(
         out_dir, ufo.info.familyName, ufo.info.styleName)
 
-    # Defcon seems to fail trying to update UFOs
-    # TODO(jamesgk) maybe look into this
+    # make sure old UFO data is removed (may contain deleted glyphs)
     if os.path.exists(out_path):
         shutil.rmtree(out_path)
 

--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -16,6 +16,7 @@
 from __future__ import print_function, division, absolute_import
 
 import os
+import shutil
 
 from glyphsLib.builder import set_redundant_data, set_custom_params,\
     clear_data, build_style_name, write_ufo, build_ufo_path, GLYPHS_PREFIX
@@ -40,6 +41,10 @@ def interpolate(ufos, master_dir, out_dir, instance_data,
         ufos, master_dir, out_dir, instance_data, italic)
 
     print('>>> Building instances')
+    # make sure old UFO data is removed (may contain deleted glyphs)
+    for path, _ in instance_files:
+        if os.path.exists(path):
+            shutil.rmtree(path)
     build(designspace_path, outputUFOFormatVersion=3)
 
     instance_ufos = []


### PR DESCRIPTION
For reason described in comments. When a UFO is overwritten, old glyphs are never removed. So we have to do this manually.

Should fix any issue for which removing old output was the solution. cc @marekjez86