### PR TITLE
Add code for writing typed/untyped data to glyphs files.

### DIFF
--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -20,7 +20,8 @@ import json
 import re
 
 __all__ = [
-    'cast_data'
+    'cast_data',
+    'uncast_data'
 ]
 
 
@@ -53,7 +54,8 @@ CUSTOM_FLOAT_PARAMS = frozenset((
 
 CUSTOM_TRUTHY_PARAMS = frozenset((
     'isFixedPitch', 'postscriptForceBold', 'postscriptIsFixedPitch',
-    "Don't use Production Names", 'DisableAllAutomaticBehaviour'))
+    u'Don\u2019t use Production Names', 'DisableAllAutomaticBehaviour'))
+
 
 CUSTOM_INTLIST_PARAMS = frozenset((
     'fsType', 'openTypeOS2CodePageRanges', 'openTypeOS2FamilyClass',
@@ -61,304 +63,460 @@ CUSTOM_INTLIST_PARAMS = frozenset((
     'panose', 'unicodeRanges'))
 
 
-def cast_data(data, types=None):
-    """Cast the attributes of parsed glyphs file content."""
+class RWGlyphs(object):
+    def convert(self, data, to_typed):
+        return self.read(data) if to_typed else self.write(data)
 
-    if types is None:
-        types = get_type_structure()
+    def read(self, src):
+        """Return a typed value representing the structured glyphs strings."""
+        raise NotImplementedError('%s read' % type(self).__name__)
+
+    def write(self, val):
+        """Return structured glyphs strings representing the typed value."""
+        raise NotImplementedError('%s write' % type(self).__name__)
+
+
+class RWBackground(RWGlyphs):
+    """Use background type structure to cast a single dictionary."""
+    def convert(self, data, to_typed):
+        _convert_data(data, to_typed, _BACKGROUND_TYPE_STRUCTURE)
+        return data
+
+
+class RWDefault(RWGlyphs):
+    """Passes src, val through unchanged."""
+
+    def read(self, src):
+        return src
+
+    def write(self, val):
+        return val
+
+
+class RWString(RWGlyphs):
+    """Reads/writes the value as a string.  Same behavior as default, but
+    here so we can keep the distinction clear.  Default can get lists as
+    arguments, this should only get strings."""
+
+    def read(self, src):
+        return src
+
+    def write(self, val):
+        if not isinstance(val, basestring):
+            print('val (%s): "%s"' % (type(val).__name__, val))
+            raise ValueError('not a string')
+        return val
+
+
+class RWTruthy(RWGlyphs):
+    """Reads/write a boolean."""
+
+    def read(self, src):
+        return bool(int(src))
+
+    def write(self, val):
+        assert isinstance(val, bool)
+        return str(int(val))
+
+
+class RWInteger(RWGlyphs):
+    """Read/write an int."""
+
+    def read(self, src):
+        return int(src)
+
+    def write(self, val):
+        assert isinstance(val, int)
+        return str(val)
+
+
+class RWNum(RWGlyphs):
+    """Read/write an int or float."""
+
+    def read(self, src):
+        float_val = float(src)
+        int_val = int(float_val)
+        return int_val if int_val == float_val else float_val
+
+    def write(self, val):
+        assert isinstance(val, float) or isinstance(val, int)
+        return str(val)
+
+
+class RWHexInt(RWGlyphs):
+    """Read/write a hex int."""
+
+    def read(self, src):
+        return int(src, 16)
+
+    def write(self, val):
+        assert isinstance(val, int)
+        return '%04X' % val
+
+
+class RWVector(RWGlyphs):
+    """Read/write a vector in curly braces."""
+
+    def __init__(self, dimension):
+        self.dimension = dimension
+        self.regex = re.compile('{%s}' % ', '.join(['([-.e\d]+)'] * dimension))
+
+    def read(self, src):
+        """Parse a vector from a string with format {X, Y, Z, ...}."""
+        return [num.read(i) for i in self.regex.match(src).groups()]
+
+    def write(self, val):
+        assert isinstance(val, list) and len(val) == self.dimension
+        return '{%s}' % (', '.join(str(v) for v in val))
+
+
+class RWPoint(RWVector):
+    """Read/write a two-element vector."""
+    def __init__(self):
+        RWVector.__init__(self, 2)
+
+
+class RWTransform(RWVector):
+    """Read/write a six-element vector."""
+
+    def __init__(self):
+        RWVector.__init__(self, 6)
+
+
+class RWNode(RWGlyphs):
+    """Read/write a node on an outline."""
+
+    _regex = re.compile(
+        '([-.e\d]+) ([-.e\d]+) (LINE|CURVE|OFFCURVE|n/a)(?: (SMOOTH))?')
+
+    def read(self, src):
+        """Cast a node from a string with format X Y TYPE [SMOOTH]."""
+        g = self._regex.match(src).groups()
+        return [num.read(g[0]), num.read(g[1]), g[2].lower(), bool(g[3])]
+
+    def write(self, val):
+        assert isinstance(val, list) and len(val) == 4
+        v2 = val[2]
+        # glyphs has this lower case
+        if v2 != 'n/a':
+            v2 = v2.upper()
+        return '%s %s %s%s' % (val[0], val[1], v2, ' SMOOTH' if val[3] else '')
+
+
+class RWIntList(RWGlyphs):
+    """Read/write a list of ints."""
+
+    def read(self, src):
+        assert isinstance(src, list)
+        return map(int, src)
+
+    def write(self, val):
+        assert isinstance(val, list)
+        return map(str, val)
+
+
+class RWPointList(RWGlyphs):
+    """Read/write a list of points."""
+
+    def read(self, src):
+        assert isinstance(src, list)
+        return map(point.read, src)
+
+    def write(self, val):
+        assert isinstance(val, list)
+        return map(point.write, val)
+
+
+class RWNodeList(RWGlyphs):
+    """Read/write a list of nodes."""
+
+    def read(self, src):
+        assert isinstance(src, list)
+        return map(node.read, src)
+
+    def write(self, val):
+        return map(node.write, val)
+
+
+class RWDateTime(RWGlyphs):
+    """Read/write a datetime.  Doesn't maintain time zone offset."""
+
+    def read(self, src):
+        """Parse a datetime object from a string."""
+        # parse timezone ourselves, since %z is not always supported
+        # see: http://bugs.python.org/issue6641
+        string, tz = src.rsplit(' ', 1)
+        datetime_obj = datetime.datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
+        offset = datetime.timedelta(hours=int(tz[:3]), minutes=int(tz[0] + tz[3:]))
+        return datetime_obj + offset
+
+    def write(self, val):
+        return str(val) + ' +0000'
+
+
+class RWKerning(RWGlyphs):
+    """Read/write kerning data structure."""
+
+    def read(self, src):
+        """Cast the values in kerning data to ints."""
+        for master_id, master_map in src.items():
+            for left_glyph, glyph_map in master_map.items():
+                for right_glyph, value in glyph_map.items():
+                    glyph_map[right_glyph] = num.read(value)
+        return src
+
+    def write(self, val):
+        for master_id, master_map in val.items():
+            for left_glyph, glyph_map in master_map.items():
+                for right_glyph, value in glyph_map.items():
+                    glyph_map[right_glyph] = num.write(value)
+        return val
+
+
+class RWDescenderVal(RWNum):
+    """Read and check value of descender."""
+
+    def read(self, src):
+        val = int(src)
+        assert val < 0
+        return val
+
+
+class RWVersionMinor(RWNum):
+    """Read and check value of minor version."""
+
+    def read(self, src):
+        val = int(src)
+        assert 0 <= val <= 999
+        return val
+
+
+class RWCustomParams(RWGlyphs):
+    """Read/write custom params."""
+
+    def read(self, src):
+        assert isinstance(src, list)
+        for param in src:
+            name = param['name']
+            value = param['value']
+
+            if name in CUSTOM_INT_PARAMS:
+                value = int(value)
+            elif name in CUSTOM_FLOAT_PARAMS:
+                value = float(value)
+            elif name in CUSTOM_TRUTHY_PARAMS:
+                value = truthy.read(value)
+            elif name in CUSTOM_INTLIST_PARAMS:
+                value = intlist.read(value)
+
+            param['value'] = value
+        return src
+
+    def write(self, val):
+        assert isinstance(val, list)
+        for param in val:
+            name = param['name']
+            value = param['value']
+
+            if name in CUSTOM_INT_PARAMS:
+                value = str(value)
+            elif name in CUSTOM_FLOAT_PARAMS:
+                value = str(value)
+            elif name in CUSTOM_TRUTHY_PARAMS:
+                value = truthy.write(value)
+            elif name in CUSTOM_INTLIST_PARAMS:
+                value = intlist.write(value)
+            param['value'] = value
+        return val
+
+
+class RWUserData(RWGlyphs):
+    """Read/write some known user data."""
+
+    _num_params = ('GSOffsetHorizontal', 'GSOffsetVertical')
+
+    def read(self, src):
+        """Cast some known user data."""
+        new_data = {}
+        for k, v in src.items():
+            if k in RWUserData._num_params:
+                new_data[k] = num.read(v)
+        src.update(new_data)
+        return src
+
+    def write(self, val):
+        new_data = {}
+        for k, v in val.items():
+            if k in RWUserData._num_params:
+                new_data[k] = num.write(v)
+        val.update(new_data)
+        return val
+
+
+# Like singletons, but... not.  Used as type structure values.
+
+background = RWBackground()
+default = RWDefault()
+string = RWString()
+integer = RWInteger()
+truthy = RWTruthy()
+num = RWNum()
+hex_int = RWHexInt()
+point = RWPoint()
+transform = RWTransform()
+node = RWNode()
+intlist = RWIntList()
+pointlist = RWPointList()
+nodelist = RWNodeList()
+glyphs_datetime = RWDateTime()
+kerning = RWKerning()
+descender_val = RWDescenderVal()
+version_minor = RWVersionMinor()
+custom_params = RWCustomParams()
+user_data = RWUserData()
+
+
+# Type hierarchy for a glyph background.
+_BACKGROUND_TYPE_STRUCTURE = {
+    'anchors': {
+        'name': string,
+        'position': point
+    },
+    'annotations': default,  # undocumented
+    'components': {
+        'anchor': string,
+        'disableAlignment': truthy,  # undocumented
+        'locked': truthy,  # undocumented
+        'name': string,
+        'transform': transform
+    },
+    'guideLines': {  # undocumented
+        'angle': num,
+        'position': point
+    },
+    'hints': default,  # undocumented
+    'leftMetricsKey': string,
+    'rightMetricsKey': string,
+    'name': string,
+    'paths': {
+        'closed': truthy,
+        'nodes': nodelist
+    },
+    'width': num
+}
+
+# Type hierarchy for a glyph layer.
+_LAYER_TYPE_STRUCTURE = dict(_BACKGROUND_TYPE_STRUCTURE)
+_LAYER_TYPE_STRUCTURE.update({
+        'associatedMasterId': string,
+        'background': background,
+        'layerId': string
+    })
+
+
+# The highest-level type hierarchy for glyphs data.
+# https://github.com/schriftgestalt/GlyphsSDK/blob/master/GlyphsFileFormat.md
+_TYPE_STRUCTURE = {
+    'DisplayStrings': default,
+    'classes': {
+        'automatic': truthy,
+        'code': string,
+        'name': string
+    },
+    'copyright': string,
+    'customParameters': custom_params,
+    'date': glyphs_datetime,
+    'designer': string,
+    'designerURL': string,
+    'disablesAutomaticAlignment': truthy,  # undocumented
+    'disablesNiceNames': truthy,  # undocumented
+    'familyName': string,
+    'featurePrefixes': {
+        'automatic': truthy,  # undocumented
+        'code': string,
+        'name': string
+    },
+    'features': {
+        'automatic': truthy,
+        'code': string,
+        'disabled': truthy,  # undocumented
+        'name': string,
+        'notes': string,  # undocumented
+    },
+    'fontMaster': {
+        'alignmentZones': pointlist,
+        'ascender': integer,
+        'capHeight': integer,
+        'customParameters': custom_params,
+        'customValue': integer,  # undocumented
+        'descender': descender_val,
+        'guideLines': {  # undocumented
+            'angle': num,
+            'locked': truthy,  # undocumented
+            'position': point
+        },
+        'horizontalStems': intlist,
+        'id': string,
+        'italicAngle': num,  # undocumented
+        'userData': user_data,
+        'verticalStems': intlist,
+        'weight': string,  # undocumented
+        'weightValue': num,
+        'width': string,  # undocumented
+        'widthValue': num,
+        'xHeight': integer
+    },
+    'glyphs': {
+        'color': integer,  # undocumented
+        'export': truthy,  # undocumented
+        'glyphname': string,
+        'lastChange': glyphs_datetime,
+        'layers': _LAYER_TYPE_STRUCTURE,
+        'leftKerningGroup': string,
+        'leftMetricsKey': string,
+        'note': string,  # undocumented
+        'production': string,
+        'rightKerningGroup': string,
+        'rightMetricsKey': string,
+        'unicode': hex_int,
+        'widthMetricsKey': string  # undocumented
+    },
+    'instances': {
+        'active': truthy,  # undocumented
+        'customParameters': custom_params,
+        'interpolationCustom': integer,  # undocumented
+        'interpolationWeight': integer,  # undocumented
+        'interpolationWidth': integer,  # undocumented
+        'name': string,  # undocumented
+        'weightClass': string,  # undocumented
+        'widthClass': string  # undocumented
+    },
+    'kerning': kerning,
+    'manufacturer': string,
+    'manufacturerURL': string,
+    'unitsPerEm': integer,
+    'userData': user_data,
+    'versionMajor': integer,
+    'versionMinor': version_minor
+}
+
+def cast_data(data):
+    _convert_data(data, True, _TYPE_STRUCTURE)
+
+
+def uncast_data(data):
+    _convert_data(data, False, _TYPE_STRUCTURE)
+
+
+def _convert_data(data, to_typed, types):
+    """Cast the attributes of parsed glyphs file content."""
 
     for key, cur_type in types.items():
         if key not in data:
             continue
-        if type(cur_type) == dict:
+        if isinstance(cur_type, dict):
+            # data[key] is a list of data of type dict
             for cur_data in data[key]:
-                cast_data(cur_data, dict(cur_type))
+                _convert_data(cur_data, to_typed, cur_type)
         else:
-            data[key] = cur_type(data[key])
-
-
-def get_type_structure():
-    """Generate and return the highest-level type hierarchy for glyphs data.
-    https://github.com/schriftgestalt/GlyphsSDK/blob/master/GlyphsFileFormat.md
-    """
-
-    return {
-        'DisplayStrings': list,
-        'classes': {
-            'automatic': truthy,
-            'code': normalized,
-            'name': str
-        },
-        'copyright': str,
-        'customParameters': custom_params,
-        'date': glyphs_datetime,
-        'designer': str,
-        'designerURL': str,
-        'disablesAutomaticAlignment': truthy,  # undocumented
-        'disablesNiceNames': truthy,  # undocumented
-        'familyName': str,
-        'featurePrefixes': {
-            'automatic': truthy,  # undocumented
-            'code': normalized,
-            'name': str
-        },
-        'features': {
-            'automatic': truthy,
-            'code': normalized,
-            'disabled': truthy,  # undocumented
-            'name': str,
-            'notes': normalized  # undocumented
-        },
-        'fontMaster': {
-            'alignmentZones': pointlist,
-            'ascender': int,
-            'capHeight': int,
-            'customParameters': custom_params,
-            'customValue': int,  # undocumented
-            'descender': descender_val,
-            'guideLines': {  # undocumented
-                'angle': num,
-                'locked': truthy,  # undocumented
-                'position': point
-            },
-            'horizontalStems': intlist,
-            'id': str,
-            'italicAngle': num,  # undocumented
-            'userData': user_data,
-            'verticalStems': intlist,
-            'weight': str,  # undocumented
-            'weightValue': num,
-            'width': str,  # undocumented
-            'widthValue': num,
-            'xHeight': int
-        },
-        'glyphs': {
-            'color': int,  # undocumented
-            'export': truthy,  # undocumented
-            'glyphname': str,
-            'lastChange': glyphs_datetime,
-            'layers': get_layer_type_structure(),
-            'leftKerningGroup': str,
-            'leftMetricsKey': str,
-            'note': str,  # undocumented
-            'production': str,
-            'rightKerningGroup': str,
-            'rightMetricsKey': str,
-            'unicode': hex_int,
-            'widthMetricsKey': str  # undocumented
-        },
-        'instances': {
-            'active': truthy,  # undocumented
-            'customParameters': custom_params,
-            'interpolationCustom': int,  # undocumented
-            'interpolationWeight': int,  # undocumented
-            'interpolationWidth': int,  # undocumented
-            'name': str,  # undocumented
-            'weightClass': str,  # undocumented
-            'widthClass': str  # undocumented
-        },
-        'kerning': kerning,
-        'manufacturer': str,
-        'manufacturerURL': str,
-        'unitsPerEm': int,
-        'userData': user_data,
-        'versionMajor': int,
-        'versionMinor': version_minor
-    }
-
-
-def get_layer_type_structure():
-    """Generate and return type hierarchy for a glyph layer."""
-
-    structure = get_background_type_structure()
-    structure.update({
-        'associatedMasterId': str,
-        'background': background,
-        'layerId': str
-    })
-    return structure
-
-
-def get_background_type_structure():
-    """Generate and return type hierarchy for a glyph background."""
-
-    return {
-        'anchors': {
-            'name': str,
-            'position': point
-        },
-        'annotations': default,  # undocumented
-        'components': {
-            'anchor': str,
-            'disableAlignment': truthy,  # undocumented
-            'locked': truthy,  # undocumented
-            'name': str,
-            'transform': transform
-        },
-        'guideLines': {  # undocumented
-            'angle': num,
-            'position': point
-        },
-        'hints': default,  # undocumented
-        'leftMetricsKey': str,
-        'rightMetricsKey': str,
-        'name': str,
-        'paths': {
-            'closed': truthy,
-            'nodes': nodelist
-        },
-        'width': num
-    }
-
-
-def background(data):
-    """Use background type structure to cast a single dictionary."""
-
-    cast_data(data, get_background_type_structure())
-    return data
-
-
-def default(value):
-    """Just return the value (i.e. don't cast it to anything)."""
-    return value
-
-
-def truthy(string):
-    """Determine if an int stored in a string is truthy."""
-    return bool(int(string))
-
-
-def num(string):
-    """Prefer casting to int, but use float if necessary."""
-
-    val = float(string)
-    int_val = int(val)
-    return int_val if int_val == val else val
-
-
-def hex_int(string):
-    """Return the hexidecimal value represented by a string."""
-    return int(string, 16)
-
-
-def vector(string, dimension):
-    """Parse a vector from a string with format {X, Y, Z, ...}."""
-
-    rx = '{%s}' % ', '.join(['([-.e\d]+)'] * dimension)
-    return [num(i) for i in re.match(rx, string).groups()]
-
-
-def point(string):
-    return vector(string, 2)
-
-
-def transform(string):
-    return vector(string, 6)
-
-
-def node(string):
-    """Cast a node from a string with format X Y TYPE [SMOOTH]."""
-
-    rx = '([-.e\d]+) ([-.e\d]+) (LINE|CURVE|OFFCURVE|n/a)(?: (SMOOTH))?'
-    m = re.match(rx, string).groups()
-    return [num(m[0]), num(m[1]), m[2].lower(), bool(m[3])]
-
-
-def intlist(strlist):
-    return map(int, strlist)
-
-
-def pointlist(strlist):
-    return map(point, strlist)
-
-
-def nodelist(strlist):
-    return map(node, strlist)
-
-
-def glyphs_datetime(string):
-    """Parse a datetime object from a string."""
-
-    # parse timezone ourselves, since %z is not always supported
-    # see: http://bugs.python.org/issue6641
-    string, tz = string.rsplit(' ', 1)
-    datetime_obj = datetime.datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
-    offset = datetime.timedelta(hours=int(tz[:3]), minutes=int(tz[0] + tz[3:]))
-    return datetime_obj + offset
-
-
-def kerning(kerning_data):
-    """Cast the values in kerning data to ints."""
-
-    new_data = {}
-    for master_id, master_map in kerning_data.items():
-        new_data[master_id] = {}
-        for left_glyph, glyph_map in master_map.items():
-            new_data[master_id][left_glyph] = {}
-            for right_glyph, value in glyph_map.items():
-                new_data[master_id][left_glyph][right_glyph] = num(value)
-    return new_data
-
-
-def descender_val(string):
-    """Ensure that descender values are always negative."""
-
-    num = int(string)
-    assert num < 0
-    return num
-
-
-def version_minor(string):
-    """Ensure that the minor version number is between 0 and 999."""
-
-    num = int(string)
-    assert num >= 0 and num <= 999
-    return num
-
-
-def normalized(string):
-    """Replace escaped characters with their intended characters.
-    Unescapes curved quotes to straight quotes, so that we can definitely
-    include this casted data in feature syntax.
-    """
-
-    replacements = (
-        ('\\012', '\n'), ('\\011', '\t'), ('\\U2018', "'"), ('\\U2019', "'"),
-        ('\\U201C', '"'), ('\\U201D', '"'))
-    for escaped, unescaped in replacements:
-        string = string.replace(escaped, unescaped)
-    return string
-
-
-def custom_params(param_list):
-    """Cast some known data in custom parameters."""
-
-    for param in param_list:
-        name = normalized(param['name'])
-        value = param['value']
-
-        param['name'] = name
-        if name in CUSTOM_INT_PARAMS:
-            param['value'] = int(value)
-        if name in CUSTOM_FLOAT_PARAMS:
-            param['value'] = float(value)
-        if name in CUSTOM_TRUTHY_PARAMS:
-            param['value'] = truthy(value)
-        if name in CUSTOM_INTLIST_PARAMS:
-            param['value'] = intlist(value)
-
-    return param_list
-
-
-def user_data(data_dict):
-    """Cast some known user data."""
-
-    num_params = ('GSOffsetHorizontal', 'GSOffsetVertical')
-
-    new_data = {}
-    for key, val in data_dict.items():
-        if key in num_params:
-            new_data[key] = num(val)
-
-    data_dict.update(new_data)
-    return data_dict
+            data[key] = cur_type.convert(data[key], to_typed)

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -148,7 +148,7 @@ class Writer(object):
     # underscore with period or leading forward slash.  Everything else
     # is quoted.
     _sym_re = re.compile(
-        r'^(?:-?[0-9]+\.?[0-9]*|[_a-zA-Z0-9/\.][_a-zA-Z0-9\.]*)$')
+        r'^(?:-?\.[0-9]+|-?[0-9]+\.?[0-9]*|[_a-zA-Z0-9/\.][_a-zA-Z0-9\.]*)$')
 
     def __init__(self, out=sys.stdout, indent=0, reorder=False):
         self.out = out
@@ -205,14 +205,16 @@ class Writer(object):
         out.write(' ' * self.curindent)
         out.write(')')
 
-    _escape_re = re.compile(u'[^\u0020-\u007e]')
+    _escape_re = re.compile(u'([^\u0020-\u007e])|"')
 
     @staticmethod
     def _escape_fn(m):
-        v = ord(m.group()[0])
-        if v < 0x20:
-            return r'\%03o' % v
-        return r'\U%04X' % v
+        if m.group(1):
+            v = ord(m.group(1)[0])
+            if v < 0x20:
+                return r'\%03o' % v
+            return r'\U%04X' % v
+        return r'\"'
 
     def _write_atom(self, data):
       data = Writer._escape_re.sub(Writer._escape_fn, data)
@@ -220,7 +222,6 @@ class Writer(object):
       if Writer._sym_re.match(data):
           out.write(data)
           return
-      data = data.replace('"', '\\"')
       out.write('"')
       out.write(data)
       out.write('"')


### PR DESCRIPTION
This changes the parsing code to handle octal/unicode escapes as well
as quotes.  This means that unicode values are returned from the parser,
and may be passed to the writer.

The casting code no longer normalizes curly quotes, they are maintained in
the data.  If they need to normalized clients will need to do that conversion.
This allows for better round-tripping of the original glyphs data.

Note that it is not possible to fully round-trip the glyphs source.  In
particular leading spaces are not preserved.  Quoting of strings is also
not fully preserved, instead the determination of whether strings need to
be quoted is done based on the contents of the string.  Glyphs seems to
quote and indent based on the position of the element in the hierarchy and
not on the content.  This does not appear to impact Glyphs' ability to
load the rewritten source.

Analysis of the casting code revealed that the dictionaries describing the
type structure were never modified and so did not need to be created/copied,
so the former functions returning them were changed to constants.

The original casting functions were converted to read methods of a collection
of objects, to which corresponding 'write' methods were added, and the
loop that iterated over the structure was changed to call a 'convert' method
with a parameter indicating whether to read or write.

In some cases the original casting functions were cloning parts of the
data structure they were operating on, and some of these were changed to
modify the data in place like the bulk of the code.  This was not done
in all cases, however-- in particular map is used in a number of functions
and it created a new list (which is then substituted for the original).