### PR TITLE
Change interpolation{Weight,Width,Custom} from int to num

### DIFF
--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -485,9 +485,9 @@ _TYPE_STRUCTURE = {
     'instances': {
         'active': truthy,  # undocumented
         'customParameters': custom_params,
-        'interpolationCustom': integer,  # undocumented
-        'interpolationWeight': integer,  # undocumented
-        'interpolationWidth': integer,  # undocumented
+        'interpolationCustom': num,  # undocumented
+        'interpolationWeight': num,  # undocumented
+        'interpolationWidth': num,  # undocumented
         'name': string,  # undocumented
         'weightClass': string,  # undocumented
         'widthClass': string  # undocumented


### PR DESCRIPTION
Glyphs seems to accept floats for instances' interpolation values, so they should be `num`, like #21.