### PR TITLE
Add a "family-name" parameter to public functions

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -48,23 +48,31 @@ def loads(value, dict_type=dict):
     return data
 
 
-def load_to_ufos(filename, include_instances=False, debug=False):
+def load_to_ufos(filename, include_instances=False, family_name=None,
+                 debug=False):
     """Load an unpacked .glyphs object to UFO objects."""
 
     with open(filename, 'rb') as ifile:
         data = load(ifile)
     print('>>> Loading to UFOs')
-    return to_ufos(data, include_instances=include_instances, debug=debug)
+    return to_ufos(data, include_instances=include_instances,
+                   family_name=family_name, debug=debug)
 
 
-def build_masters(filename, master_dir, designspace_instance_dir=None):
+def build_masters(filename, master_dir, designspace_instance_dir=None,
+                  family_name=None):
     """Write and return UFOs from the masters defined in a .glyphs file.
 
-    If `designspace_instance_dir` is provided, a designspace document will be
-    written alongside the master UFOs, though no instances will be built.
+    Args:
+        master_dir: Directory where masters are written.
+        designspace_instance_dir: If provided, a designspace document will be
+            written alongside the master UFOs though no instances will be built.
+        family_name: If provided, the master UFOs will be given this name and
+            only instances with this name will be included in the designspace.
     """
 
-    ufos, instance_data = load_to_ufos(filename, include_instances=True)
+    ufos, instance_data = load_to_ufos(
+        filename, include_instances=True, family_name=family_name)
     if designspace_instance_dir is not None:
         build_designspace(ufos, master_dir, designspace_instance_dir,
                           instance_data)
@@ -74,11 +82,18 @@ def build_masters(filename, master_dir, designspace_instance_dir=None):
     return ufos
 
 
-def build_instances(filename, master_dir, instance_dir):
-    """Write and return UFOs from the instances defined in a .glyphs file."""
+def build_instances(filename, master_dir, instance_dir, family_name=None):
+    """Write and return UFOs from the instances defined in a .glyphs file.
+
+    Args:
+        master_dir: Directory where masters are written.
+        instance_dir: Directory where instances are written.
+        family_name: If provided, the master UFOs will be given this name and
+            only instances with this name will be built.
+    """
 
     master_ufos, instance_data = load_to_ufos(
-        filename, include_instances=True)
+        filename, include_instances=True, family_name=family_name)
     instance_ufos = interpolate(
         master_ufos, master_dir, instance_dir, instance_data)
     return instance_ufos

--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -128,7 +128,7 @@ def add_masters_to_writer(writer, ufos):
     return base_family, base_style
 
 
-def add_instances_to_writer(writer, family_name, instances, out_dir):
+def add_instances_to_writer(writer, family_name, instance_data, out_dir):
     """Add instances from Glyphs data to a MutatorMath document writer.
 
     Returns a list of <ufo_path, font_data> pairs, corresponding to the
@@ -136,20 +136,23 @@ def add_instances_to_writer(writer, family_name, instances, out_dir):
     Glyphs data for this instance as a dict.
     """
 
+    default_family_name = instance_data.pop('defaultFamilyName')
     ofiles = []
-    for instance in instances:
+    for instance in instance_data.pop('data'):
 
         if not instance.pop('active', True):
             continue
 
-        # use family name in instance data if available
-        instance_family = family_name
+        # only use instances with the masters' family name
+        instance_family = default_family_name
         custom_params = instance.get('customParameters', ())
         for i in range(len(custom_params)):
             if custom_params[i]['name'] == 'familyName':
                 instance_family = custom_params[i]['value']
                 del custom_params[i]
                 break
+        if instance_family != family_name:
+            continue
 
         style_name = instance.pop('name')
         ufo_path = build_ufo_path(out_dir, instance_family, style_name)


### PR DESCRIPTION
This allows one to only build certain instances found in a Glyphs source, filtering by family name, or to give a custom family name to generated masters.

Related to https://github.com/googlei18n/noto-source/pull/6, we want to generate separate normal/UI masters for a certain script each with it's own interpolation rules (found in Glyphs source). This seemed like the most convenient way.