### PR TITLE
Always parse into ordered dictionaries

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -29,18 +29,18 @@ __all__ = [
 ]
 
 
-def load(fp, dict_type=dict):
+def load(fp):
     """Read a .glyphs file. 'fp' should be (readable) file object.
-    Return the unpacked root object (which usually is a dictionary).
+    Return the unpacked root object (an ordered dictionary).
     """
-    return loads(fp.read(), dict_type=dict_type)
+    return loads(fp.read())
 
 
-def loads(value, dict_type=dict):
+def loads(value):
     """Read a .glyphs file from a bytes object.
-    Return the unpacked root object (which usually is a dictionary).
+    Return the unpacked root object (an ordered dictionary).
     """
-    p = Parser(dict_type=dict_type)
+    p = Parser()
     print('>>> Parsing .glyphs file')
     data = p.parse(value)
     print('>>> Casting parsed values')

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -15,14 +15,15 @@
 
 from __future__ import print_function, division, absolute_import
 
-import re, sys
+import collections
+import re
+import sys
 
 
 class Parser:
     """Parses Python dictionaries from Glyphs source files."""
 
-    def __init__(self, dict_type):
-        self.dict_type = dict_type
+    def __init__(self):
         value_re = r'(".*?(?<!\\)"|[-_./$A-Za-z0-9]+)'
         self.start_dict_re = re.compile(r'\s*{')
         self.end_dict_re = re.compile(r'\s*}')
@@ -68,7 +69,7 @@ class Parser:
     def _parse_dict(self, text, i):
         """Parse a dictionary from source text starting at i."""
 
-        res = self.dict_type()
+        res = collections.OrderedDict()
         end_match = self.end_dict_re.match(text, i)
         while not end_match:
             m = self.attr_re.match(text, i)


### PR DESCRIPTION
Now that kerning conflict resolution depends on the order the rules
are defined, it is always necessary to use an ordered dictionary to
store the Glyphs data.