### PR TITLE
Add specific version number to test data

### DIFF
--- a/Lib/glyphsLib/builder_test.py
+++ b/Lib/glyphsLib/builder_test.py
@@ -151,7 +151,7 @@ class SetRedundantDataTest(unittest.TestCase):
 class ToUfosTest(unittest.TestCase):
     def generate_minimal_data(self):
         return {
-            '.appVersion': 1,
+            '.appVersion': 895,
             'date': datetime.datetime.today(),
             'familyName': 'MyFont',
             'fontMaster': [{


### PR DESCRIPTION
Now that the tested code checks for a specific version number, the
default value should be something that doesn't raise any warnings.