### PR TITLE
Expose more functionality for interpolating

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -73,17 +73,23 @@ def build_masters(filename, master_dir, designspace_instance_dir=None,
             written alongside the master UFOs though no instances will be built.
         family_name: If provided, the master UFOs will be given this name and
             only instances with this name will be included in the designspace.
+
+    Returns:
+        A list of master UFOs, and if designspace_instance_dir is provided, a
+        path to a designspace and a list of (path, data) tuples with instance
+        paths from the designspace and respective data from the Glyphs source.
     """
 
     ufos, instance_data = load_to_ufos(
         filename, include_instances=True, family_name=family_name)
     if designspace_instance_dir is not None:
-        build_designspace(ufos, master_dir, designspace_instance_dir,
-                          instance_data)
+        designspace_path, instance_data = build_designspace(
+            ufos, master_dir, designspace_instance_dir, instance_data)
+        return ufos, designspace_path, instance_data
     else:
         for ufo in ufos:
             write_ufo(ufo, master_dir)
-    return ufos
+        return ufos
 
 
 def build_instances(filename, master_dir, instance_dir, family_name=None):

--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -22,7 +22,7 @@ from glyphsLib.builder import set_redundant_data, set_custom_params,\
     clear_data, write_ufo, build_ufo_path, clean_ufo, GLYPHS_PREFIX
 
 __all__ = [
-    'interpolate', 'build_designspace'
+    'interpolate', 'build_designspace', 'apply_instance_data'
 ]
 
 
@@ -33,7 +33,6 @@ def interpolate(ufos, master_dir, out_dir, instance_data, debug=False):
     """Create MutatorMath designspace and generate instances.
     Returns instance UFOs, or unused instance data if debug is True.
     """
-    from defcon import Font
     from mutatorMath.ufo import build
 
     designspace_path, instance_files = build_designspace(
@@ -44,14 +43,7 @@ def interpolate(ufos, master_dir, out_dir, instance_data, debug=False):
         clean_ufo(path)
     build(designspace_path, outputUFOFormatVersion=3)
 
-    instance_ufos = []
-    for path, data in instance_files:
-        ufo = Font(path)
-        set_custom_params(ufo, data=data)
-        set_redundant_data(ufo)
-        ufo.save()
-        instance_ufos.append(ufo)
-
+    instance_ufos = apply_instance_data(instance_files)
     if debug:
         return clear_data(instance_data)
     return instance_ufos
@@ -173,3 +165,24 @@ def add_instances_to_writer(writer, family_name, instance_data, out_dir):
         writer.endInstance()
 
     return ofiles
+
+
+def apply_instance_data(instance_data):
+    """Open instances, apply data, and re-save.
+
+    Args:
+        instance_data: List of (path, data) tuples, one for each instance.
+        dst_ufo_list: List to add opened instances to.
+    Returns:
+        List of opened and updated instance UFOs.
+    """
+    from defcon import Font
+
+    instance_ufos = []
+    for path, data in instance_data:
+        ufo = Font(path)
+        set_custom_params(ufo, data=data)
+        set_redundant_data(ufo)
+        ufo.save()
+        instance_ufos.append(ufo)
+    return instance_ufos


### PR DESCRIPTION
This returns a designspace path and instance data when a designspace
is generated in the build_master function, and adds a function for
incorporating this instance data (which reflects the structure of
Glyphs source) into actual UFOs.

Ideally I'd like to take out interpolation from glyphsLib completely,
and only have options for returning master UFOs and a designspace. But
for now I'm not sure if anyone is using the interpolation feature.