### PR TITLE
[interpolation] Copy lib data to instances

### DIFF
--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -116,7 +116,8 @@ def add_masters_to_writer(writer, ufos):
         writer.addSource(
             path=path, name='%s %s' % (family, style),
             familyName=family, styleName=style, location=location,
-            copyFeatures=is_base, copyGroups=is_base, copyInfo=is_base)
+            copyFeatures=is_base, copyGroups=is_base, copyInfo=is_base,
+            copyLib=is_base)
 
     return base_family, base_style
 


### PR DESCRIPTION
Some of this data will be technically incorrect for most instances,
for example the weight name and value. However, all of this incorrect
data resides in entries with a Glyphs-specific prefix and will
generally be ignored.

What we care about is the public.glyphOrder entry, which does need to
be present in any generated instance (and should be the same across a
family).

Fixes https://github.com/googlei18n/fontmake/issues/175