### PR TITLE
Explicitly set OpenType ascender/descender fields

### DIFF
--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -293,14 +293,16 @@ def set_redundant_data(ufo):
     ufo.info.openTypeNamePreferredSubfamilyName = style_name
 
     ascender = ufo.info.ascender
-    ufo.info.openTypeHheaAscender = ascender
-    ufo.info.openTypeOS2TypoAscender = ascender
-    ufo.info.openTypeOS2WinAscent = ascender
+    if ascender is not None:
+        ufo.info.openTypeHheaAscender = ascender
+        ufo.info.openTypeOS2TypoAscender = ascender
+        ufo.info.openTypeOS2WinAscent = ascender
 
     descender = ufo.info.descender
-    ufo.info.openTypeHheaDescender = descender
-    ufo.info.openTypeOS2TypoDescender = descender
-    ufo.info.openTypeOS2WinDescent = abs(descender)
+    if descender is not None:
+        ufo.info.openTypeHheaDescender = descender
+        ufo.info.openTypeOS2TypoDescender = descender
+        ufo.info.openTypeOS2WinDescent = abs(descender)
 
 
 def set_custom_params(ufo, parsed=None, data=None, misc_keys=(), non_info=()):

--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -292,6 +292,16 @@ def set_redundant_data(ufo):
     ufo.info.openTypeNamePreferredFamilyName = family_name
     ufo.info.openTypeNamePreferredSubfamilyName = style_name
 
+    ascender = ufo.info.ascender
+    ufo.info.openTypeHheaAscender = ascender
+    ufo.info.openTypeOS2TypoAscender = ascender
+    ufo.info.openTypeOS2WinAscent = ascender
+
+    descender = ufo.info.descender
+    ufo.info.openTypeHheaDescender = descender
+    ufo.info.openTypeOS2TypoDescender = descender
+    ufo.info.openTypeOS2WinDescent = abs(descender)
+
 
 def set_custom_params(ufo, parsed=None, data=None, misc_keys=(), non_info=()):
     """Set Glyphs custom parameters in UFO info or lib, where appropriate.


### PR DESCRIPTION
These turn out to be pretty complicated and we can't trust they'll
be set correctly by a UFO compiler just from the generic fields.

Glyphs does something a little different, but this is a simple
treatment which yields predictable results for the common case where
every master has the same ascender and descender values.