### PR TITLE
Round integer custom parameters

### DIFF
--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -145,11 +145,10 @@ class RWNum(RWGlyphs):
 
     def read(self, src):
         float_val = float(src)
-        int_val = int(float_val)
-        return int_val if int_val == float_val else float_val
+        return int(float_val) if float_val.is_integer() else float_val
 
     def write(self, val):
-        assert isinstance(val, float) or isinstance(val, int)
+        assert isinstance(val, (float, int))
         return str(val)
 
 

--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -15,7 +15,7 @@
 
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
-from fontTools.misc.py23 import basestring
+from fontTools.misc.py23 import basestring, round
 import datetime
 import logging
 import re
@@ -306,7 +306,7 @@ class RWCustomParams(RWGlyphs):
             value = param['value']
 
             if name in CUSTOM_INT_PARAMS:
-                value = int(value)
+                value = round(float(value))
             elif name in CUSTOM_FLOAT_PARAMS:
                 value = float(value)
             elif name in CUSTOM_TRUTHY_PARAMS:
@@ -324,7 +324,7 @@ class RWCustomParams(RWGlyphs):
             value = param['value']
 
             if name in CUSTOM_INT_PARAMS:
-                value = str(value)
+                value = str(round(value))
             elif name in CUSTOM_FLOAT_PARAMS:
                 value = str(value)
             elif name in CUSTOM_TRUTHY_PARAMS:

--- a/tests/casting_test.py
+++ b/tests/casting_test.py
@@ -17,7 +17,7 @@ from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
 import unittest
-from glyphsLib.casting import cast_data
+from glyphsLib.casting import cast_data, num, custom_params
 
 
 class GlyphsDatetimeTest(unittest.TestCase):
@@ -54,6 +54,56 @@ class GlyphsDatetimeTest(unittest.TestCase):
         self.compare_parsed_date_string(
             '2001-02-03 00:05:06 -0010',
             (2001, 2, 2, 23, 55, 6))
+
+
+class RWNumTest(unittest.TestCase):
+
+    def test_read(self):
+        self.assertEqual(num.read('1.0'), 1)
+        self.assertEqual(num.read('-10.0'), -10)
+        self.assertEqual(num.read('1.1'), 1.1)
+
+    def test_write(self):
+        self.assertEqual(num.write(1), '1')
+        self.assertEqual(num.write(-10), '-10')
+        self.assertEqual(num.write(1.1), '1.1')
+
+
+class RWCustomParamsTest(unittest.TestCase):
+
+    def test_read(self):
+        src = [
+            {'name': 'underlinePosition', 'value': '-77.5'},
+            {'name': 'postscriptBlueScale', 'value': '0.039625'},
+            {'name': 'isFixedPitch', 'value': '0'},
+            {'name': 'Don\u2019t use Production Names', 'value': '1'},
+            {'name': 'unicodeRanges', 'value': ['0', '1', '2']}
+        ]
+        result = custom_params.read(src)
+        self.assertEqual(result, [
+            {'name': 'underlinePosition', 'value': -78},
+            {'name': 'postscriptBlueScale', 'value': 0.039625},
+            {'name': 'isFixedPitch', 'value': False},
+            {'name': 'Don\u2019t use Production Names', 'value': True},
+            {'name': 'unicodeRanges', 'value': [0, 1, 2]}
+        ])
+
+    def test_write(self):
+        src = [
+            {'name': 'underlinePosition', 'value': -77.5},
+            {'name': 'postscriptBlueScale', 'value': 0.039625},
+            {'name': 'isFixedPitch', 'value': False},
+            {'name': 'Don\u2019t use Production Names', 'value': True},
+            {'name': 'unicodeRanges', 'value': [0, 1, 2]}
+        ]
+        result = custom_params.write(src)
+        self.assertEqual(result, [
+            {'name': 'underlinePosition', 'value': '-78'},
+            {'name': 'postscriptBlueScale', 'value': '0.039625'},
+            {'name': 'isFixedPitch', 'value': '0'},
+            {'name': 'Don\u2019t use Production Names', 'value': '1'},
+            {'name': 'unicodeRanges', 'value': ['0', '1', '2']}
+        ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
glyphsLib expect some of the custom parameters, e.g. `underlinePosition`, to contain integer values. But if the glyphs source happens to contain a float string, casting that to int() would raise a ValueError. Better rounding the float to integer instead.

Partial fix for googlei18n/fontmake#247

BTW, I wonder from where @jamesgk got the full list of custom parameters, and whether they have to be interpreted as integer, float, boolean, list of integers or plain strings.
Does anybody know?