### PR TITLE
set OS/2 fsSelection flags 7 and 8 from custom parameters

### DIFF
--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -301,15 +301,18 @@ def set_custom_params(ufo, parsed=None, data=None, misc_keys=(), non_info=()):
     else:
         assert data is None, "Shouldn't provide parsed data and data to parse."
 
+    fsSelection_flags = {'Use Typo Metrics', 'Has WWS Names'}
     for name, value in parsed:
         name = normalize_custom_param_name(name)
 
-        # special cases
-        if name == 'Has WWS Names':
-            try:
-                ufo.info.openTypeOS2Selection.append(8)
-            except AttributeError:
-                ufo.info.openTypeOS2Selection = [8]
+        if name in fsSelection_flags:
+            if value:
+                if ufo.info.openTypeOS2Selection is None:
+                    ufo.info.openTypeOS2Selection = []
+                if name == 'Use Typo Metrics':
+                    ufo.info.openTypeOS2Selection.append(7)
+                elif name == 'Has WWS Names':
+                    ufo.info.openTypeOS2Selection.append(8)
             continue
 
         # deal with any Glyphs naming quirks here

--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -60,7 +60,8 @@ CUSTOM_NUM_PARAMS = CUSTOM_INT_PARAMS | CUSTOM_FLOAT_PARAMS
 
 CUSTOM_TRUTHY_PARAMS = frozenset((
     'isFixedPitch', 'postscriptForceBold', 'postscriptIsFixedPitch',
-    'Don\u2019t use Production Names', 'DisableAllAutomaticBehaviour'))
+    'Don\u2019t use Production Names', 'DisableAllAutomaticBehaviour',
+    'Use Typo Metrics', 'Has WWS Names'))
 
 
 CUSTOM_INTLIST_PARAMS = frozenset((

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -36,26 +36,26 @@ class BuildStyleNameTest(unittest.TestCase):
         return build_style_name(data, 'width', 'weight', 'custom', italic)
 
     def test_style_regular_weight(self):
-        self.assertEquals(self._build({}, False), 'Regular')
-        self.assertEquals(self._build({}, True), 'Italic')
-        self.assertEquals(
+        self.assertEqual(self._build({}, False), 'Regular')
+        self.assertEqual(self._build({}, True), 'Italic')
+        self.assertEqual(
             self._build({'weight': 'Regular'}, True), 'Italic')
 
     def test_style_nonregular_weight(self):
-        self.assertEquals(
+        self.assertEqual(
             self._build({'weight': 'Thin'}, False), 'Thin')
-        self.assertEquals(
+        self.assertEqual(
             self._build({'weight': 'Thin'}, True), 'Thin Italic')
 
     def test_style_nonregular_width(self):
-        self.assertEquals(
+        self.assertEqual(
             self._build({'width': 'Condensed'}, False), 'Condensed')
-        self.assertEquals(
+        self.assertEqual(
             self._build({'width': 'Condensed'}, True), 'Condensed Italic')
-        self.assertEquals(
+        self.assertEqual(
             self._build({'weight': 'Thin', 'width': 'Condensed'}, False),
             'Condensed Thin')
-        self.assertEquals(
+        self.assertEqual(
             self._build({'weight': 'Thin', 'width': 'Condensed'}, True),
             'Condensed Thin Italic')
 
@@ -87,7 +87,7 @@ class SetRedundantDataTest(unittest.TestCase):
     def test_sets_regular_weight_class_for_missing_weight(self):
         reg_ufo = self._run_on_ufo('MyFont', 'Regular')
         italic_ufo = self._run_on_ufo('MyFont', 'Italic')
-        self.assertEquals(
+        self.assertEqual(
             reg_ufo.info.openTypeOS2WeightClass,
             italic_ufo.info.openTypeOS2WeightClass)
 
@@ -112,8 +112,8 @@ class SetRedundantDataTest(unittest.TestCase):
     def _run_style_map_names_test(self, args):
         for family, style, expected_family, expected_style in args:
             ufo = self._run_on_ufo(family, style)
-            self.assertEquals(ufo.info.styleMapFamilyName, expected_family)
-            self.assertEquals(ufo.info.styleMapStyleName, expected_style)
+            self.assertEqual(ufo.info.styleMapFamilyName, expected_family)
+            self.assertEqual(ufo.info.styleMapStyleName, expected_style)
 
     def test_sets_legal_style_map_names(self):
         self._run_style_map_names_test((

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -75,6 +75,22 @@ class SetCustomParamsTest(unittest.TestCase):
         set_custom_params(ufo, parsed=[('glyphOrder', ['A', 'B'])])
         self.assertEqual(ufo.lib[PUBLIC_PREFIX + 'glyphOrder'], ['A', 'B'])
 
+    def test_set_fsSelection_flags(self):
+        ufo = Font()
+        self.assertEqual(ufo.info.openTypeOS2Selection, None)
+
+        ufo = Font()
+        set_custom_params(ufo, parsed=[('Has WWS Names', False)])
+        self.assertEqual(ufo.info.openTypeOS2Selection, None)
+
+        set_custom_params(ufo, parsed=[('Use Typo Metrics', True)])
+        self.assertEqual(ufo.info.openTypeOS2Selection, [7])
+
+        ufo = Font()
+        set_custom_params(ufo, parsed=[('Has WWS Names', True),
+                                       ('Use Typo Metrics', True)])
+        self.assertEqual(ufo.info.openTypeOS2Selection, [8, 7])
+
 
 class SetRedundantDataTest(unittest.TestCase):
     def _run_on_ufo(self, family_name, style_name):


### PR DESCRIPTION
Before this, only "Has WWS Names" was supported, though it was properly not checking the True/False value, but just if the custom param was present.