### PR TITLE
Do not generate inactive instances

### DIFF
--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -152,8 +152,11 @@ def add_instances_to_writer(writer, family_name, instance_data, out_dir):
             dimension_names.append(s)
 
     for instance in instance_data:
+        # Glyphs.app recognizes both "exports=0" and "active=0" as a flag
+        # to mark instances as inactive. Those should not be instantiated.
         # https://github.com/googlei18n/glyphsLib/issues/129
-        if not instance.pop('exports', True):
+        if (not int(instance.pop('exports', 1))
+            or not int(instance.pop('active', 1))):
             continue
 
         instance_family = default_family_name

--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -156,7 +156,7 @@ def add_instances_to_writer(writer, family_name, instance_data, out_dir):
         # to mark instances as inactive. Those should not be instantiated.
         # https://github.com/googlei18n/glyphsLib/issues/129
         if (not int(instance.pop('exports', 1))
-            or not int(instance.pop('active', 1))):
+                or not int(instance.pop('active', 1))):
             continue
 
         instance_family = default_family_name

--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -152,8 +152,8 @@ def add_instances_to_writer(writer, family_name, instance_data, out_dir):
             dimension_names.append(s)
 
     for instance in instance_data:
-
-        if not instance.pop('active', True):
+        # https://github.com/googlei18n/glyphsLib/issues/129
+        if not instance.pop('exports', True):
             continue
 
         instance_family = default_family_name

--- a/tests/interpolation_test.py
+++ b/tests/interpolation_test.py
@@ -71,7 +71,17 @@ class DesignspaceTest(unittest.TestCase):
         self.expect_designspace(masters, instances,
                                 "DesignspaceTestBasic.designspace")
 
-    def test_inactive(self):
+    def test_inactive_from_active(self):
+        # Glyphs.app recognizes active=0 as a flag for inactive instances.
+        # https://github.com/googlei18n/glyphsLib/issues/129
+        masters, instances = makeFamily("DesignspaceTest Inactive")
+        for inst in instances["data"]:
+            inst["active"] = (1 if inst["name"] == "Semibold" else 0)
+        self.expect_designspace(masters, instances,
+                                "DesignspaceTestInactive.designspace")
+
+    def test_inactive_from_exports(self):
+        # Glyphs.app recognizes exports=0 as a flag for inactive instances.
         # https://github.com/googlei18n/glyphsLib/issues/129
         masters, instances = makeFamily("DesignspaceTest Inactive")
         for inst in instances["data"]:

--- a/tests/interpolation_test.py
+++ b/tests/interpolation_test.py
@@ -72,9 +72,10 @@ class DesignspaceTest(unittest.TestCase):
                                 "DesignspaceTestBasic.designspace")
 
     def test_inactive(self):
+        # https://github.com/googlei18n/glyphsLib/issues/129
         masters, instances = makeFamily("DesignspaceTest Inactive")
         for inst in instances["data"]:
-            inst["active"] = (inst["name"] == "Semibold")
+            inst["exports"] = (1 if inst["name"] == "Semibold" else 0)
         self.expect_designspace(masters, instances,
                                 "DesignspaceTestInactive.designspace")
 


### PR DESCRIPTION
Before this change, the code was looking for an attribute named
`active`, but this is not what Glyphs.app stores in its files when an
instance gets marked as inactive in the Glyphs user interface. Instead,
Glyphs calls this attribute `exports` in its files.

Fixes https://github.com/googlei18n/glyphsLib/issues/129.