### PR TITLE
Recognize custom parameters for weightClass and widthClass

### DIFF
--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -263,8 +263,10 @@ def set_redundant_data(ufo):
     family_name, style_name = ufo.info.familyName, ufo.info.styleName
 
     width, weight = parse_style_attrs(style_name)
-    ufo.info.openTypeOS2WidthClass = WIDTH_CODES[width]
-    ufo.info.openTypeOS2WeightClass = WEIGHT_CODES[weight]
+    if ufo.info.openTypeOS2WidthClass is None:
+        ufo.info.openTypeOS2WidthClass = WIDTH_CODES[width]
+    if ufo.info.openTypeOS2WeightClass is None:
+        ufo.info.openTypeOS2WeightClass = WEIGHT_CODES[weight]
 
     if weight and weight != 'Regular':
         ufo.lib[GLYPHS_PREFIX + 'weight'] = weight
@@ -326,6 +328,8 @@ def set_custom_params(ufo, parsed=None, data=None, misc_keys=(), non_info=()):
             ('hhea', 'Hhea'), ('description', 'NameDescription'),
             ('license', 'NameLicense'), ('panose', 'OS2Panose'),
             ('typo', 'OS2Typo'), ('unicodeRanges', 'OS2UnicodeRanges'),
+            ('weightClass', 'OS2WeightClass'),
+            ('widthClass', 'OS2WidthClass'),
             ('win', 'OS2Win'), ('vendorID', 'OS2VendorID'),
             ('versionString', 'NameVersion'), ('fsType', 'OS2Type'))
         for glyphs_prefix, ufo_prefix in opentype_attr_prefix_pairs:
@@ -339,6 +343,10 @@ def set_custom_params(ufo, parsed=None, data=None, misc_keys=(), non_info=()):
         # enforce that winAscent/Descent are positive, according to UFO spec
         if name.startswith('openTypeOS2Win') and value < 0:
             value = -value
+
+        # Some Glyphs files store weightClass/widthClass as string values.
+        if name in ('openTypeOS2WeightClass', 'openTypeOS2WidthClass'):
+            value = int(value)
 
         if name == 'glyphOrder':
             # store the public.glyphOrder in lib.plist

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -326,6 +326,54 @@ class ToUfosTest(unittest.TestCase):
         postscriptNames = ufo.lib.get('public.postscriptNames')
         self.assertEqual(postscriptNames, {'C-fraktur': 'uni212D'})
 
+    def test_weightClass_default(self):
+        data = self.generate_minimal_data()
+        ufo = to_ufos(data)[0]
+        self.assertEqual(ufo.info.openTypeOS2WeightClass, 400)
+
+    def test_weightClass_from_customParameter_weightClass(self):
+        # In the test input, the width is specified twice: once as weight,
+        # once as customParameters.weightClass. We expect that the latter wins
+        # because the Glyphs handbook documents that the weightClass value
+        # overrides the setting in the Weight drop-down list.
+        # https://glyphsapp.com/content/1-get-started/2-manuals/1-handbook-glyphs-2-0/Glyphs-Handbook-2.3.pdf#page=202
+        data = self.generate_minimal_data()
+        master = data['fontMaster'][0]
+        master['weight'] = 'Bold'  # 700
+        master['customParameters'] = ({'name': 'weightClass', 'value': '698'},)
+        ufo = to_ufos(data)[0]
+        self.assertEqual(ufo.info.openTypeOS2WeightClass, 698)  # 698, not 700
+
+    def test_weightClass_from_weight(self):
+        data = self.generate_minimal_data()
+        data['fontMaster'][0]['weight'] = 'Bold'
+        ufo = to_ufos(data)[0]
+        self.assertEqual(ufo.info.openTypeOS2WeightClass, 700)
+
+    def test_widthClass_default(self):
+        data = self.generate_minimal_data()
+        ufo = to_ufos(data)[0]
+        self.assertEqual(ufo.info.openTypeOS2WidthClass, 5)
+
+    def test_widthClass_from_customParameter_widthClass(self):
+        # In the test input, the width is specified twice: once as width,
+        # once as customParameters.widthClass. We expect that the latter wins
+        # because the Glyphs handbook documents that the widthClass value
+        # overrides the setting in the Width drop-down list.
+        # https://glyphsapp.com/content/1-get-started/2-manuals/1-handbook-glyphs-2-0/Glyphs-Handbook-2.3.pdf#page=203
+        data = self.generate_minimal_data()
+        master = data['fontMaster'][0]
+        master['width'] = 'Extra Condensed'  # 2
+        master['customParameters'] = ({'name': 'widthClass', 'value': '7'},)
+        ufo = to_ufos(data)[0]
+        self.assertEqual(ufo.info.openTypeOS2WidthClass, 7)  # 7, not 2
+
+    def test_widthClass_from_width(self):
+        data = self.generate_minimal_data()
+        data['fontMaster'][0]['width'] = 'Extra Condensed'
+        ufo = to_ufos(data)[0]
+        self.assertEqual(ufo.info.openTypeOS2WidthClass, 2)
+
     def test_GDEF(self):
         data = self.generate_minimal_data()
         for glyph in ('space', 'A', 'A.alt',


### PR DESCRIPTION
The new behavior matches what is documented in the Glyphs handbook.
After this change, glyphsLib will produce the same `openTypeOS2WeightClass`
and `openTypeOS2WidthClass` values as Glyphs.app.

Note that this change does _not_ fix the `fvar` table in variation
fonts, but at least glyphsLib now produces interpolation masters
with correct OS/2 tables so it's a step towards correctness.

https://github.com/googlei18n/fontmake/issues/167