### PR TITLE
[glyphdata] Improve the unicode value returned by get_glyph. Fixes #141

### DIFF
--- a/tests/glyphdata_test.py
+++ b/tests/glyphdata_test.py
@@ -43,7 +43,8 @@ class GlyphDataTest(unittest.TestCase):
         self.assertEqual(uni("fi"), "ﬁ")
         self.assertIsNone(uni("s_t"))  # no 'unicode' in GlyphsData
         self.assertEqual(uni("Gcommaaccent"), "Ģ")
-        self.assertEqual(uni("o_f_f_i.foo"), "offi")
+        self.assertIsNone(uni("o_f_f_i.foo")) # no single unicode via agl
+        self.assertIsNone(uni("a.sc")) # alternate glyph
 
     def test_category(self):
         cat = lambda n: (get_glyph(n).category, get_glyph(n).subCategory)


### PR DESCRIPTION
Ensure get_glyph returns a unicode with length==1

Use special unicode string length calculation

As pointed out by @anthrotype in https://github.com/googlei18n/glyphsLib/issues/141#issuecomment-283495409
Thanks!

Don't use agl if a '.' or '_' is in name; restructuring. See #141