### PR TITLE
Add command line option to pass in a custom GlyphData.xml file

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -21,11 +21,12 @@ from __future__ import (print_function, division, absolute_import,
 from io import open
 import logging
 
+from glyphsLib import glyphdata_generated
 from glyphsLib.builder import to_ufos
 from glyphsLib.casting import cast_data
 from glyphsLib.interpolation import interpolate, build_designspace
 from glyphsLib.parser import Parser
-from glyphsLib.util import write_ufo
+from glyphsLib.util import fetch, write_ufo, fetch_all_glyphs, build_data, test_data, GlyphData
 
 
 __version__ = "1.5.3.dev0"
@@ -56,8 +57,52 @@ def loads(value):
     return data
 
 
+def load_glyph_data(data=glyphdata_generated, glyphs_source=None, custom_glyph_xml=None):
+    """Load GlyphData.xml
+    If a custom GlyphData.xml exists merge it with the default GlyphData.xml
+    Two overrides are possible:
+        1. Reading from a custom GlyphData.xml
+        2. Manually changing the info in Glyphs app
+    Args:
+        data: pre-generated glyph data
+        glyphs_source: unpacked .glyphs object
+        custom_glyph_xml: Path to a custom GlyphData.xml file
+    """
+    glyph_dict = data.DEFAULT_GLYPH_DICT.copy()
+    if custom_glyph_xml:
+        custom_glyphs = {}
+        lines = None
+        with open(custom_glyph_xml, 'r') as f:
+            lines = f.read()
+        if lines:
+            custom_glyphs = fetch_all_glyphs(paths=(lines,))
+        glyph_dict.update(custom_glyphs)
+
+    # Check the .glyphs file for any overrides
+    if glyphs_source:
+        for g in glyphs_source['glyphs']:
+            name = g.get('glyphname')
+            category = g.get('category')
+            subCategory = g.get('subCategory')
+            if g.get('category') is None and g.get('subCategory') is None:
+                continue
+            if name in glyph_dict:
+                glyph_dict[name]['category'] = category
+                glyph_dict[name]['subCategory'] = subCategory
+            else:
+                glyphs_gdef = {name: {}}
+                glyphs_gdef[name]['category'] = category
+                glyphs_gdef[name]['subCategory'] = subCategory
+                glyph_dict.update(glyphs_gdef)
+
+    glyph_data = build_data(glyph_dict)
+    test_data(glyph_dict, glyph_data)
+    logger.info('Loading custom GlyphData.xml')
+    return glyph_data
+
+
 def load_to_ufos(file_or_path, include_instances=False, family_name=None,
-                 debug=False):
+                 debug=False, custom_glyph_xml=None):
     """Load an unpacked .glyphs object to UFO objects."""
 
     if hasattr(file_or_path, 'read'):
@@ -65,13 +110,16 @@ def load_to_ufos(file_or_path, include_instances=False, family_name=None,
     else:
         with open(file_or_path, 'r', encoding='utf-8') as ifile:
             data = load(ifile)
+
+    glyph_data = load_glyph_data(glyphs_source=data, custom_glyph_xml=custom_glyph_xml)
+
     logger.info('Loading to UFOs')
     return to_ufos(data, include_instances=include_instances,
-                   family_name=family_name, debug=debug)
+                   family_name=family_name, debug=debug, glyph_data=glyph_data)
 
 
 def build_masters(filename, master_dir, designspace_instance_dir=None,
-                  family_name=None):
+                  family_name=None, custom_glyph_xml=None):
     """Write and return UFOs from the masters defined in a .glyphs file.
 
     Args:
@@ -80,6 +128,7 @@ def build_masters(filename, master_dir, designspace_instance_dir=None,
             written alongside the master UFOs though no instances will be built.
         family_name: If provided, the master UFOs will be given this name and
             only instances with this name will be included in the designspace.
+        custom_glyph_xml: Path to a custom GlyphData.xml file.
 
     Returns:
         A list of master UFOs, and if designspace_instance_dir is provided, a
@@ -88,7 +137,7 @@ def build_masters(filename, master_dir, designspace_instance_dir=None,
     """
 
     ufos, instance_data = load_to_ufos(
-        filename, include_instances=True, family_name=family_name)
+        filename, include_instances=True, family_name=family_name, custom_glyph_xml=custom_glyph_xml)
     if designspace_instance_dir is not None:
         designspace_path, instance_data = build_designspace(
             ufos, master_dir, designspace_instance_dir, instance_data)
@@ -99,7 +148,7 @@ def build_masters(filename, master_dir, designspace_instance_dir=None,
         return ufos
 
 
-def build_instances(filename, master_dir, instance_dir, family_name=None):
+def build_instances(filename, master_dir, instance_dir, family_name=None, custom_glyph_xml=None):
     """Write and return UFOs from the instances defined in a .glyphs file.
 
     Args:
@@ -107,10 +156,11 @@ def build_instances(filename, master_dir, instance_dir, family_name=None):
         instance_dir: Directory where instances are written.
         family_name: If provided, the master UFOs will be given this name and
             only instances with this name will be built.
+        custom_glyph_xml: Path to a custom GlyphData.xml file.
     """
 
     master_ufos, instance_data = load_to_ufos(
-        filename, include_instances=True, family_name=family_name)
+        filename, include_instances=True, family_name=family_name, custom_glyph_xml=custom_glyph_xml)
     instance_ufos = interpolate(
         master_ufos, master_dir, instance_dir, instance_data)
     return instance_ufos

--- a/Lib/glyphsLib/__main__.py
+++ b/Lib/glyphsLib/__main__.py
@@ -36,8 +36,10 @@ def parse_options(args):
                         help="Glyphs file to convert.")
     parser.add_argument("-m", "--masters", metavar="MASTERS",
                         default="master_ufo",
-                        help="Ouput masters UFO to folder MASTERS. "
+                        help="Output masters UFO to folder MASTERS. "
                              "(default: %(default)s)")
+    parser.add_argument("-c", "--custom-glyph-data", metavar="CUSTOM_GLYPH_DATA",
+                        help="Path to a custom GlyphData.xml file")
     parser.add_argument("-n", "--instances", metavar="INSTANCES", nargs="?",
                         const="instance_ufo", default=None,
                         help="Output and generate interpolated instances UFO "
@@ -51,9 +53,9 @@ def main(args=None):
     opt = parse_options(args)
     if opt.glyphs is not None:
         if opt.instances is None:
-            glyphsLib.build_masters(opt.glyphs, opt.masters)
+            glyphsLib.build_masters(opt.glyphs, opt.masters, opt.custom_glyph_data)
         else:
-            glyphsLib.build_instances(opt.glyphs, opt.masters, opt.instances)
+            glyphsLib.build_instances(opt.glyphs, opt.masters, opt.instances, opt.custom_glyph_data)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -80,6 +80,15 @@ def _get_category(name, unistr, data=glyphdata_generated):
         return ("Symbol", "Geometry")
     if basename.startswith("uniF9"):
         return ("Letter", "Compatibility")
+
+    glyph_info = glyphdata_generated.DEFAULT_GLYPH_DICT.get(name)
+    if glyph_info is None:
+        glyph_info = glyphdata_generated.DEFAULT_GLYPH_DICT.get(basename)
+    if glyph_info is not None:
+        category, subCategory = glyph_info.get('category'), glyph_info.get('subCategory')
+        if (category, subCategory) != (None, None):
+            return (category, subCategory)
+
     ucat = _get_unicode_category(unistr)
     cat = data.DEFAULT_CATEGORIES.get(ucat, (None, None))
     if "_" in basename:

--- a/Lib/glyphsLib/util.py
+++ b/Lib/glyphsLib/util.py
@@ -13,11 +13,52 @@
 # limitations under the License.
 
 
+import json
 import logging
 import os
 import shutil
+import urllib
+import xml.etree.ElementTree as etree
+
+from collections import Counter, defaultdict, namedtuple
+from glyphsLib.glyphdata import get_glyph, _get_unicode_category, _get_category
+
+import fontTools.agl
+from fontTools.misc.py23 import *
+
 
 logger = logging.getLogger(__name__)
+
+GlyphData = namedtuple('GlyphData', [
+    'PRODUCTION_NAMES',
+    'IRREGULAR_UNICODE_STRINGS',
+    'MISSING_UNICODE_STRINGS',
+    'DEFAULT_CATEGORIES',
+    'IRREGULAR_CATEGORIES',
+])
+
+
+def fetch_url(url):
+    try:
+        from urllib.request import urlopen
+    except ImportError:
+        from urllib2 import urlopen
+    stream = urlopen(url)
+    content = stream.read()
+    stream.close()
+    return content.decode('utf-8')
+
+
+def fetch(filename):
+    return fetch_url(
+        "https://raw.githubusercontent.com/schriftgestalt/GlyphsInfo/master/"
+        + filename)
+
+
+def fetch_data_version():
+    last_commit_info = fetch_url(
+        "https://api.github.com/repos/schriftgestalt/GlyphsInfo/commits/master")
+    return json.loads(last_commit_info)["sha"]
 
 
 def build_ufo_path(out_dir, family_name, style_name):
@@ -68,3 +109,104 @@ def clear_data(data):
                 i += 1
         return data
     return True
+
+
+def fetch_all_glyphs(paths=()):
+    glyphs = {}
+    for fileobj in paths:
+        for glyph in etree.fromstring(fileobj).findall("glyph"):
+            glyphName = glyph.attrib["name"]
+            assert glyphName not in glyphs, "multiple entries for " + glyphName
+            glyphs[glyphName] = glyph.attrib
+    return glyphs
+
+
+def build_data(glyphs):
+    default_categories, irregular_categories = build_categories(glyphs)
+    prodnames = {}
+    irregular_unicode_strings = {}
+    missing_unicode_strings = set()
+    for name, glyph in glyphs.items():
+        prodname = glyph.get("production", name)
+        if prodname != name:
+            prodnames[name] = prodname
+        inferred_unistr = fontTools.agl.toUnicode(prodname)
+        unistr = glyph.get("unicode")
+        unistr = unichr(int(unistr, 16)) if unistr else None
+        if unistr is None:
+            missing_unicode_strings.add(name)
+        elif unistr != inferred_unistr:
+            irregular_unicode_strings[name] = unistr
+    return GlyphData(prodnames,
+                     irregular_unicode_strings,
+                     missing_unicode_strings,
+                     default_categories,
+                     irregular_categories,
+                     )
+
+
+def build_categories(glyphs):
+    counts = defaultdict(Counter)
+    unicode_strings = {}
+    for name, glyph in glyphs.items():
+        prodname = glyph.get("production", name)
+        unistr = unicode_strings[name] = fontTools.agl.toUnicode(prodname)
+        unicode_category = _get_unicode_category(unistr)
+        category = (glyph.get("category"), glyph.get("subCategory"))
+        counts[unicode_category][category] += 1
+    default_categories = {"Cc": ("Separator", None)}
+    for key, value in counts.items():
+        cat, _count = value.most_common(1)[0]
+        default_categories[key] = cat
+
+    # Find irregular categories. Whether it makes much sense for
+    # Glyphs.app to disagree with Unicode about Unicode categories,
+    # and whether it's a great idea to introduce inconsistencies (for
+    # example, other than Unicode, Glyphs does not assign the same
+    # category to "ampersand" and "ampersand.full"), is an entirely
+    # moot question. Our goal here is to return the same properties as
+    # encoded in GlyphsData.xml, so that glyphsLib produces the same
+    # output as Glyphs.app.
+    #
+    # Changing the category of one glyph can affect the category of
+    # others. To handle this correctly, we execute a simple fixed
+    # point algorithm. Each iteration looks for glyphs whose category
+    # is different from what we'd have inferred from the current data
+    # tables; any irregularities get added to the irregular_categories
+    # exception list. If the last iteration has discovered additional
+    # irregularites, we do another round, trying to expand the exception
+    # list until we cannot find any more.
+    irregular_categories = {}
+    data = GlyphData({}, {}, set(), default_categories, irregular_categories)
+    changed = True
+    while changed:
+        changed = False
+        for name, glyph in glyphs.items():
+            inferred_category = _get_category(name, unicode_strings[name], data)
+            category = (glyph.get("category"), glyph.get("subCategory"))
+            if category != inferred_category:
+                irregular_categories[name] = category
+                changed = True
+    return default_categories, irregular_categories
+
+
+def test_data(glyphs, data):
+    """Runs checks on the generated GlyphData
+
+    Makes sure that the implementation of glyphsLib.glyphdata.get_glyph(),
+    if it were to work on the generated GlyphData, will produce the exact
+    same results as the original data files.
+    """
+    for _, glyph in sorted(glyphs.items()):
+        name = glyph["name"]
+        prod = glyph.get("production", name)
+        unicode = glyph.get("unicode")
+        unicode = unichr(int(unicode, 16)) if unicode else None
+        category = glyph.get("category")
+        subCategory = glyph.get("subCategory")
+        g = get_glyph(name, data=data)
+        assert name == g.name, (name, g.name)
+        assert prod == g.production_name, (name, prod, g.production_name)
+        assert unicode == g.unicode, (name, unicode, g.unicode)
+        assert category == g.category, (name, category, g.category)
+        assert subCategory == g.subCategory, (name, subCategory, g.subCategory)

--- a/tests/data/GlyphData.xml
+++ b/tests/data/GlyphData.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE glyphData [
+<!ELEMENT glyphData (glyph)+>
+<!ELEMENT glyph EMPTY>
+<!ATTLIST glyph
+	unicode			CDATA		#IMPLIED
+	unicode2		CDATA		#IMPLIED
+	name			CDATA		#REQUIRED
+	category		CDATA		#REQUIRED
+	subCategory		CDATA		#REQUIRED
+	script			CDATA		#IMPLIED
+	description		CDATA		#IMPLIED
+	legacy			CDATA		#IMPLIED
+	decompose		CDATA		#IMPLIED
+	anchors			CDATA		#IMPLIED
+	accents			CDATA		#IMPLIED
+	sortName		CDATA		#IMPLIED>
+]>
+<glyphData>
+
+	<glyph unicode="0061" name="a" category="Mark" subCategory="Nonspacing" script="latin" description="LATIN SMALL LETTER A" anchors="top, bottom, ogonek" accents="caroncomb, dotaccentcomb, ogonekcomb, macroncomb, brevecomb, tildecomb, circumflexcomb, acutecomb, gravecomb, ringcomb, dieresiscomb, dotbelowcomb" />
+	<glyph unicode="17C5" name="au-khmer" sortName="kh232" category="Letter" subCategory="Spacing" script="khmer" production="uni17C5" description="KHMER VOWEL SIGN AU" />
+
+</glyphData>

--- a/tests/data/TestGDEF.glyphs
+++ b/tests/data/TestGDEF.glyphs
@@ -1,0 +1,606 @@
+{
+.appVersion = "983";
+date = "2017-03-15 02:22:03 +0000";
+familyName = TestGDEF;
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0041;
+},
+{
+glyphname = B;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0042;
+},
+{
+glyphname = C;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0043;
+},
+{
+glyphname = D;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0044;
+},
+{
+glyphname = E;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0045;
+},
+{
+glyphname = F;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0046;
+},
+{
+glyphname = G;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0047;
+},
+{
+glyphname = H;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0048;
+},
+{
+glyphname = I;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0049;
+},
+{
+glyphname = J;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 004A;
+},
+{
+glyphname = K;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 004B;
+},
+{
+glyphname = L;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 004C;
+},
+{
+glyphname = M;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 004D;
+},
+{
+glyphname = N;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 004E;
+},
+{
+glyphname = O;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 004F;
+},
+{
+glyphname = P;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0050;
+},
+{
+glyphname = Q;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0051;
+},
+{
+glyphname = R;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0052;
+},
+{
+glyphname = S;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0053;
+},
+{
+glyphname = T;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0054;
+},
+{
+glyphname = U;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0055;
+},
+{
+glyphname = V;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0056;
+},
+{
+glyphname = W;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0057;
+},
+{
+glyphname = X;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0058;
+},
+{
+glyphname = Y;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0059;
+},
+{
+glyphname = Z;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 005A;
+},
+{
+glyphname = b;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0062;
+},
+{
+glyphname = c;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0063;
+},
+{
+glyphname = d;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0064;
+},
+{
+glyphname = e;
+lastChange = "2017-03-15 04:44:12 +0000";
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+paths = (
+{
+closed = 1;
+nodes = (
+"123 73 LINE",
+"476 73 LINE",
+"476 531 LINE",
+"123 531 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0065;
+},
+{
+glyphname = f;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0066;
+},
+{
+glyphname = g;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0067;
+},
+{
+glyphname = h;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0068;
+},
+{
+glyphname = i;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0069;
+},
+{
+glyphname = j;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 006A;
+},
+{
+glyphname = k;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 006B;
+},
+{
+glyphname = l;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 006C;
+},
+{
+glyphname = m;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 006D;
+},
+{
+glyphname = n;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 006E;
+},
+{
+glyphname = o;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 006F;
+},
+{
+glyphname = p;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0070;
+},
+{
+glyphname = q;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0071;
+},
+{
+glyphname = r;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0072;
+},
+{
+glyphname = s;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0073;
+},
+{
+glyphname = t;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0074;
+},
+{
+glyphname = u;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0075;
+},
+{
+glyphname = v;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0076;
+},
+{
+glyphname = w;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0077;
+},
+{
+glyphname = x;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0078;
+},
+{
+glyphname = y;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0079;
+},
+{
+glyphname = z;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 007A;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+width = 600;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = testglyph;
+lastChange = "2017-03-15 04:44:54 +0000";
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+paths = (
+{
+closed = 1;
+nodes = (
+"172 96 LINE",
+"464 96 LINE",
+"464 500 LINE",
+"172 500 LINE"
+);
+}
+);
+width = 600;
+}
+);
+category = Mark;
+subCategory = Nonspacing;
+},
+{
+glyphname = a;
+lastChange = "2017-03-15 20:08:24 +0000";
+layers = (
+{
+layerId = "18FE5AB4-9174-4130-813B-CBDD755DAB4B";
+paths = (
+{
+closed = 1;
+nodes = (
+"122 65 LINE",
+"473 65 LINE",
+"473 398 LINE",
+"122 398 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0061;
+category = Mark;
+subCategory = "Spacing Combining";
+}
+);
+instances = (
+{
+instanceInterpolations = {
+"18FE5AB4-9174-4130-813B-CBDD755DAB4B" = 1;
+};
+name = Regular;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/glyphdata_test.py
+++ b/tests/glyphdata_test.py
@@ -16,13 +16,20 @@
 
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
+from glyphsLib import glyphdata_generated
+from glyphsLib import load, load_glyph_data
 from glyphsLib.glyphdata import get_glyph
+from io import open
+import os
 import unittest
 
 
 class GlyphDataTest(unittest.TestCase):
+    def setUp(self):
+        self.glyph_data = glyphdata_generated
+
     def test_production_name(self):
-        prod = lambda n: get_glyph(n).production_name
+        prod = lambda n: get_glyph(n, data=self.glyph_data).production_name
         self.assertEqual(prod(".notdef"), ".notdef")
         self.assertEqual(prod("eacute"), "eacute")
         self.assertEqual(prod("Abreveacute"), "uni1EAE")
@@ -34,7 +41,7 @@ class GlyphDataTest(unittest.TestCase):
         self.assertEqual(prod("o_f_f_i.foo"), "o_f_f_i.foo")
 
     def test_unicode(self):
-        uni = lambda n: get_glyph(n).unicode
+        uni = lambda n: get_glyph(n, data=self.glyph_data).unicode
         self.assertIsNone(uni(".notdef"))
         self.assertEqual(uni("eacute"), "é")
         self.assertEqual(uni("Abreveacute"), "Ắ")
@@ -46,7 +53,7 @@ class GlyphDataTest(unittest.TestCase):
         self.assertEqual(uni("o_f_f_i.foo"), "offi")
 
     def test_category(self):
-        cat = lambda n: (get_glyph(n).category, get_glyph(n).subCategory)
+        cat = lambda n: (get_glyph(n, data=self.glyph_data).category, get_glyph(n, data=self.glyph_data).subCategory)
         self.assertEqual(cat(".notdef"), ("Separator", None))
         self.assertEqual(cat("uni000D"), ("Separator", None))
         self.assertEqual(cat("boxHeavyUp"), ("Symbol", "Geometry"))
@@ -61,6 +68,43 @@ class GlyphDataTest(unittest.TestCase):
         self.assertEqual(cat("o_f_f_i"), ("Letter", "Ligature"))
         self.assertEqual(cat("o_f_f_i.foo"), ("Letter", "Ligature"))
         self.assertEqual(cat("ain_alefMaksura-ar.fina"), ("Letter", "Ligature"))
+
+
+class GlyphDataCustomXMLTest(unittest.TestCase):
+    """Read from a custom GlyphData.xml and test glyph categories
+    """
+    def setUp(self):
+        path, _ = os.path.split(__file__)
+        xmlpath = os.path.join(path, "data", 'GlyphData.xml')
+        self.custom_data = load_glyph_data(custom_glyph_xml=xmlpath)
+
+    def test_category(self):
+        cat = lambda n: (get_glyph(n, self.custom_data).category, get_glyph(n, self.custom_data).subCategory)
+        self.assertEqual(cat("a"), ("Mark", "Nonspacing"))
+        self.assertEqual(cat("au-khmer"), ("Letter", "Spacing"))
+
+
+class GlyphDataFromGlyphsTest(unittest.TestCase):
+    def setUp(self):
+        path, _ = os.path.split(__file__)
+        expectedPath = os.path.join(path, "data", 'TestGDEF.glyphs')
+        data = None
+        with open(expectedPath, 'r', encoding='utf-8') as ifile:
+            data = load(ifile)
+        if data:
+            self.glyphs_gdef = {}
+            for g in data['glyphs']:
+                self.glyphs_gdef[g.get('glyphname')] = (g.get('category'), g.get('subCategory'))
+
+    def get_glyphinfo(self, glyph):
+        return self.glyphs_gdef.get(glyph)
+
+    def test_category(self):
+        """Test overridden categories saved into the .glyphs source file
+        """
+        cat = lambda n: (self.get_glyphinfo(n)[0], self.get_glyphinfo(n)[1])
+        self.assertEqual(cat("testglyph"), ("Mark", "Nonspacing"))
+        self.assertEqual(cat("A"), (None, None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Moved GlyphData.xml loading code from generate_glyphdata.py to
glyphsLib/util.py to use with custom loading.

Glyph data and therefore GDEF are now constructed by
1. Reading the default GlyphData.xml (saved in glyphdata_generated.py)
2. Reading a custom GlyphData.xml if passed
3. Reading any overrides saved in the .glyphs file

Zero the width of Nonspacing Marks when writing to UFO (like Glyphs)
As discussed in https://github.com/googlei18n/glyphsLib/issues/115 this could
be moved to ufo2ft? Also we need to check for the Glyphs custom parameter 
DisableAllAutomaticBehaviour that ignores this width zero behaviour.
Tested and looks good with Noto Sans Hebrew as reported here: 
https://github.com/googlei18n/fontmake/issues/273

Added test for loading a custom GlyphData.xml.
Added test for reading a .glyphs source file with category overrides saved in the file.