### PR TITLE
use category/subCategory overrides; zero nonspacing marks width...

### DIFF
--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -481,6 +481,7 @@ _TYPE_STRUCTURE = {
         'xHeight': integer
     },
     'glyphs': {
+        'category': string,
         'color': integer,  # undocumented
         'export': truthy,  # undocumented
         'glyphname': string,
@@ -492,6 +493,7 @@ _TYPE_STRUCTURE = {
         'production': string,
         'rightKerningGroup': string,
         'rightMetricsKey': string,
+        'subCategory': string,
         'unicode': hex_int,
         'widthMetricsKey': string  # undocumented
     },

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -335,6 +335,11 @@ class ToUfosTest(unittest.TestCase):
 
     def test_postscript_name_from_glyph_name(self):
         data = self.generate_minimal_data()
+        # in GlyphData (and AGLFN) without a 'production' name
+        self.add_glyph(data, 'A')
+        # not in GlyphData, no production name
+        self.add_glyph(data, 'foobar')
+        # in GlyphData with a 'production' name
         self.add_glyph(data, 'C-fraktur')
         ufo = to_ufos(data)[0]
         postscriptNames = ufo.lib.get('public.postscriptNames')

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -502,6 +502,18 @@ class ToUfosTest(unittest.TestCase):
         self.assertIn('LigatureCaretByPos fi 500;',
                       to_ufos(data)[0].features.text)
 
+    def test_GDEF_custom_category_subCategory(self):
+        data = self.generate_minimal_data()
+        self.add_glyph(data, 'foo')['subCategory'] = 'Ligature'
+        self.add_anchor(data, 'foo', 'top', 400, 1000)
+        bar = self.add_glyph(data, 'bar')
+        bar['category'], bar['subCategory'] = 'Mark', 'Nonspacing'
+        baz = self.add_glyph(data, 'baz')
+        baz['category'], baz['subCategory'] = 'Mark', 'Spacing Combining'
+        features = to_ufos(data)[0].features.text
+        self.assertIn('[foo], # Liga', features)
+        self.assertIn('[bar baz], # Mark', features)
+
     def test_set_blue_values(self):
         """Test that blue values are set correctly from alignment zones."""
 


### PR DESCRIPTION
We decided to revert #150 as it needed some clean up.
However, a couple of things from there could easily be incorporated.

1) if the glyph contain custom 'category' or 'subCategory' attributes embedded in the .glyphs source file itself (cf. CMD+ALT+i panel), then use that instead of global values from GlyphData.xml. Additionally, store these inside the GLIF lib under a corresponding private key. This way we can roundtrip them when we go back from UFO to .glyphs source.

2) Set the width of glyphs with category "Mark" and subCategory "Nonspacing" to 0, like Glyphs.app does upon export (fixes #115)

Finally, only store production names in the UFO lib when they differ from original glyph names. Currently we are storing even superfluous stuff like 'A' -> 'A'...

I will add some tests tomorrow.