### PR TITLE
Use weightClass and interpolationWeight as they appear in actual fonts

### DIFF
--- a/tests/data/DesignspaceTestBasic.designspace
+++ b/tests/data/DesignspaceTestBasic.designspace
@@ -8,40 +8,40 @@
             <features copy="1" />
             <info copy="1" />
             <location>
-                <dimension name="weight" xvalue="400.000000" />
+                <dimension name="weight" xvalue="90.000000" />
             </location>
         </source>
         <source familyname="DesignspaceTest Basic" filename="DesignspaceTestBasic-Black.ufo" name="DesignspaceTest Basic Black" stylename="Black">
             <location>
-                <dimension name="weight" xvalue="900.000000" />
+                <dimension name="weight" xvalue="190.000000" />
             </location>
         </source>
     </sources>
     <instances>
         <instance familyname="DesignspaceTest Basic" filename="out/DesignspaceTestBasic-Regular.ufo" name="DesignspaceTest Basic Regular" stylename="Regular">
             <location>
-                <dimension name="weight" xvalue="400.000000" />
+                <dimension name="weight" xvalue="90.000000" />
             </location>
             <info />
             <kerning />
         </instance>
         <instance familyname="DesignspaceTest Basic" filename="out/DesignspaceTestBasic-Semibold.ufo" name="DesignspaceTest Basic Semibold" stylename="Semibold">
             <location>
-                <dimension name="weight" xvalue="600.000000" />
+                <dimension name="weight" xvalue="128.000000" />
             </location>
             <info />
             <kerning />
         </instance>
         <instance familyname="DesignspaceTest Basic" filename="out/DesignspaceTestBasic-Bold.ufo" name="DesignspaceTest Basic Bold" stylename="Bold">
             <location>
-                <dimension name="weight" xvalue="700.000000" />
+                <dimension name="weight" xvalue="151.000000" />
             </location>
             <info />
             <kerning />
         </instance>
         <instance familyname="DesignspaceTest Basic" filename="out/DesignspaceTestBasic-Black.ufo" name="DesignspaceTest Basic Black" stylename="Black">
             <location>
-                <dimension name="weight" xvalue="900.000000" />
+                <dimension name="weight" xvalue="190.000000" />
             </location>
             <info />
             <kerning />

--- a/tests/data/DesignspaceTestFamilyName.designspace
+++ b/tests/data/DesignspaceTestFamilyName.designspace
@@ -8,12 +8,12 @@
             <features copy="1" />
             <info copy="1" />
             <location>
-                <dimension name="weight" xvalue="400.000000" />
+                <dimension name="weight" xvalue="90.000000" />
             </location>
         </source>
         <source familyname="DesignspaceTest FamilyName" filename="DesignspaceTestFamilyName-Black.ufo" name="DesignspaceTest FamilyName Black" stylename="Black">
             <location>
-                <dimension name="weight" xvalue="900.000000" />
+                <dimension name="weight" xvalue="190.000000" />
             </location>
         </source>
     </sources>

--- a/tests/data/DesignspaceTestInactive.designspace
+++ b/tests/data/DesignspaceTestInactive.designspace
@@ -8,19 +8,19 @@
             <features copy="1" />
             <info copy="1" />
             <location>
-                <dimension name="weight" xvalue="400.000000" />
+                <dimension name="weight" xvalue="90.000000" />
             </location>
         </source>
         <source familyname="DesignspaceTest Inactive" filename="DesignspaceTestInactive-Black.ufo" name="DesignspaceTest Inactive Black" stylename="Black">
             <location>
-                <dimension name="weight" xvalue="900.000000" />
+                <dimension name="weight" xvalue="190.000000" />
             </location>
         </source>
     </sources>
     <instances>
         <instance familyname="DesignspaceTest Inactive" filename="out/DesignspaceTestInactive-Semibold.ufo" name="DesignspaceTest Inactive Semibold" stylename="Semibold">
             <location>
-                <dimension name="weight" xvalue="600.000000" />
+                <dimension name="weight" xvalue="128.000000" />
             </location>
             <info />
             <kerning />

--- a/tests/data/DesignspaceTestInstanceOrder.designspace
+++ b/tests/data/DesignspaceTestInstanceOrder.designspace
@@ -8,12 +8,12 @@
             <features copy="1" />
             <info copy="1" />
             <location>
-                <dimension name="weight" xvalue="400.000000" />
+                <dimension name="weight" xvalue="90.000000" />
             </location>
         </source>
         <source familyname="DesignspaceTest InstanceOrder" filename="DesignspaceTestInstanceOrder-Black.ufo" name="DesignspaceTest InstanceOrder Black" stylename="Black">
             <location>
-                <dimension name="weight" xvalue="900.000000" />
+                <dimension name="weight" xvalue="190.000000" />
             </location>
         </source>
     </sources>

--- a/tests/interpolation_test.py
+++ b/tests/interpolation_test.py
@@ -32,16 +32,16 @@ from glyphsLib.interpolation import build_designspace
 def makeFamily(familyName):
     m1, m2 = defcon.Font(), defcon.Font()
     m1.info.familyName, m1.info.styleName = familyName, "Regular"
-    m1.lib[GLYPHS_PREFIX + "weightValue"] = 400.0
+    m1.lib[GLYPHS_PREFIX + "weightValue"] = 90.0
     m2.info.familyName, m2.info.styleName = familyName, "Black"
-    m2.lib[GLYPHS_PREFIX + "weightValue"] = 900.0
+    m2.lib[GLYPHS_PREFIX + "weightValue"] = 190.0
     instances = {
         "defaultFamilyName": familyName,
         "data": [
-            {"name": "Regular", "interpolationWeight": 400.0},
-            {"name": "Semibold", "interpolationWeight": 600.0},
-            {"name": "Bold", "interpolationWeight": 700.0},
-            {"name": "Black", "interpolationWeight": 900.0},
+            {"name": "Regular", "interpolationWeight": 90, "weightClass": 400},
+            {"name": "Semibold", "interpolationWeight": 128, "weightClass": 600},
+            {"name": "Bold", "interpolationWeight": 151, "weightClass": 700},
+            {"name": "Black", "interpolationWeight": 190, "weightClass": 900},
         ],
     }
     return [m1, m2], instances


### PR DESCRIPTION
No change in behavior yet. This change merely updates the test input,
so that the unit tests reflect what the compiler is actually seeing
in its input sources.

https://github.com/googlei18n/fontmake/issues/167