### PR TITLE
Write variation axes into designspace documents

### DIFF
--- a/tests/data/DesignspaceTestBasic.designspace
+++ b/tests/data/DesignspaceTestBasic.designspace
@@ -1,6 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
-    <axes />
+    <axes>
+        <axis default="400.0" maximum="900.0" minimum="400.0" name="weight" tag="wght">
+            <map input="400.0" output="90" />
+            <map input="600.0" output="128" />
+            <map input="700.0" output="151" />
+            <map input="900.0" output="190" />
+        </axis>
+    </axes>
     <sources>
         <source familyname="DesignspaceTest Basic" filename="DesignspaceTestBasic-Regular.ufo" name="DesignspaceTest Basic Regular" stylename="Regular">
             <lib copy="1" />

--- a/tests/data/DesignspaceTestFamilyName.designspace
+++ b/tests/data/DesignspaceTestFamilyName.designspace
@@ -1,6 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
-    <axes />
+    <axes>
+        <axis default="400.0" maximum="600.0" minimum="400.0" name="weight" tag="wght">
+            <map input="400.0" output="90" />
+            <map input="600.0" output="151" />
+        </axis>
+    </axes>
     <sources>
         <source familyname="DesignspaceTest FamilyName" filename="DesignspaceTestFamilyName-Regular.ufo" name="DesignspaceTest FamilyName Regular" stylename="Regular">
             <lib copy="1" />

--- a/tests/data/DesignspaceTestInactive.designspace
+++ b/tests/data/DesignspaceTestInactive.designspace
@@ -1,6 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
-    <axes />
+    <axes>
+        <axis default="600.0" maximum="600.0" minimum="600.0" name="weight" tag="wght">
+            <map input="600.0" output="128" />
+        </axis>
+    </axes>
     <sources>
         <source familyname="DesignspaceTest Inactive" filename="DesignspaceTestInactive-Regular.ufo" name="DesignspaceTest Inactive Regular" stylename="Regular">
             <lib copy="1" />

--- a/tests/data/DesignspaceTestInstanceOrder.designspace
+++ b/tests/data/DesignspaceTestInstanceOrder.designspace
@@ -1,6 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
-    <axes />
+    <axes>
+        <axis default="400.0" maximum="900.0" minimum="400.0" name="weight" tag="wght">
+            <map input="400.0" output="90" />
+            <map input="700.0" output="151" />
+            <map input="900.0" output="190" />
+        </axis>
+    </axes>
     <sources>
         <source familyname="DesignspaceTest InstanceOrder" filename="DesignspaceTestInstanceOrder-Regular.ufo" name="DesignspaceTest InstanceOrder Regular" stylename="Regular">
             <lib copy="1" />


### PR DESCRIPTION
The output files now contain the information for building `avar` tables,
and for building `fvar` tables with correct value ranges.

https://github.com/googlei18n/fontmake/issues/167