### PR TITLE
fix regression in detecting active instances

### DIFF
--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -499,6 +499,7 @@ _TYPE_STRUCTURE = {
     },
     'instances': {
         'active': truthy,  # undocumented
+        'exports': truthy,  # undocumented
         'customParameters': custom_params,
         'interpolationCustom': num,  # undocumented
         'interpolationWeight': num,  # undocumented

--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -151,7 +151,7 @@ def is_instance_active(instance):
     # Glyphs.app recognizes both "exports=0" and "active=0" as a flag
     # to mark instances as inactive. Inactive instances should get ignored.
     # https://github.com/googlei18n/glyphsLib/issues/129
-    return instance.get('exports', 1) and int(instance.get('active', 1))
+    return instance.get('exports', True) and instance.get('active', True)
 
 
 def write_axes(axes, writer):

--- a/tests/interpolation_test.py
+++ b/tests/interpolation_test.py
@@ -120,7 +120,8 @@ class DesignspaceTest(unittest.TestCase):
         # https://github.com/googlei18n/glyphsLib/issues/129
         masters, instances = makeFamily("DesignspaceTest Inactive")
         for inst in instances["data"]:
-            inst["active"] = (1 if inst["name"] == "Semibold" else 0)
+            if inst["name"] != "Semibold":
+                inst["active"] = False
         self.expect_designspace(masters, instances,
                                 "DesignspaceTestInactive.designspace")
 
@@ -129,7 +130,8 @@ class DesignspaceTest(unittest.TestCase):
         # https://github.com/googlei18n/glyphsLib/issues/129
         masters, instances = makeFamily("DesignspaceTest Inactive")
         for inst in instances["data"]:
-            inst["exports"] = (1 if inst["name"] == "Semibold" else 0)
+            if inst["name"] != "Semibold":
+                inst["exports"] = False
         self.expect_designspace(masters, instances,
                                 "DesignspaceTestInactive.designspace")
 


### PR DESCRIPTION
Fixes a regression introduced with commit https://github.com/googlei18n/glyphsLib/blob/d9d1da4e/Lib/glyphsLib/interpolation.py#L146

The 'exports' parameter was being interpreted as a string instead of as a boolean, hence the following test `if '0': ...` would always return `True`.
Notice how in line 146, the cast to `int()` was not used for the 'exports' parameter, but only for the 'active' one.

Because of this, all the instances were always generated no matter what their 'exports' value...

The tests in `interpolation_test.py` did not catch this bug, because in there we were passing an integer instead of a string as the 'exports' parameter value.

The 'exports' parameter is now explicitly being cast to boolean (db826fe).