### PR TITLE
support codePagesRanges and openTypeHheaCaretOffset custom parameters

### DIFF
--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -77,6 +77,47 @@ WIDTH_CODES = {
     'SemiCondensed': 4,
     '': 5}
 
+# https://www.microsoft.com/typography/otspec/os2.htm#cpr
+CODEPAGE_RANGES = {
+    1252: 0,
+    1250: 1,
+    1251: 2,
+    1253: 3,
+    1254: 4,
+    1255: 5,
+    1256: 6,
+    1257: 7,
+    1258: 8,
+    # 9-15: Reserved for Alternate ANSI
+    874: 16,
+    932: 17,
+    936: 18,
+    949: 19,
+    950: 20,
+    1361: 21,
+    # 22-28: Reserved for Alternate ANSI and OEM
+    # 29: Macintosh Character Set (US Roman)
+    # 30: OEM Character Set
+    # 31: Symbol Character Set
+    # 32-47: Reserved for OEM
+    869: 48,
+    866: 49,
+    865: 50,
+    864: 51,
+    863: 52,
+    862: 53,
+    861: 54,
+    860: 55,
+    857: 56,
+    855: 57,
+    852: 58,
+    775: 59,
+    737: 60,
+    708: 61,
+    850: 62,
+    437: 63,
+}
+
 
 def to_ufos(data, include_instances=False, family_name=None, debug=False):
     """Take .glyphs file data and load it into UFOs.
@@ -339,10 +380,15 @@ def set_custom_params(ufo, parsed=None, data=None, misc_keys=(), non_info=()):
             name = 'useNiceNames'
             value = int(not value)
 
+        # convert code page numbers to OS/2 ulCodePageRange bits
+        if name == 'codePageRanges':
+            value = [CODEPAGE_RANGES[v] for v in value]
+
         opentype_attr_prefix_pairs = (
             ('hhea', 'Hhea'), ('description', 'NameDescription'),
             ('license', 'NameLicense'), ('panose', 'OS2Panose'),
             ('typo', 'OS2Typo'), ('unicodeRanges', 'OS2UnicodeRanges'),
+            ('codePageRanges', 'OS2CodePageRanges'),
             ('weightClass', 'OS2WeightClass'),
             ('widthClass', 'OS2WidthClass'),
             ('win', 'OS2Win'), ('vendorID', 'OS2VendorID'),

--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -67,7 +67,7 @@ CUSTOM_TRUTHY_PARAMS = frozenset((
 CUSTOM_INTLIST_PARAMS = frozenset((
     'fsType', 'openTypeOS2CodePageRanges', 'openTypeOS2FamilyClass',
     'openTypeOS2Panose', 'openTypeOS2Type', 'openTypeOS2UnicodeRanges',
-    'panose', 'unicodeRanges'))
+    'panose', 'unicodeRanges', 'codePageRanges'))
 
 # mutate list in place
 def _mutate_list(fn, l):

--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -32,6 +32,7 @@ CUSTOM_INT_PARAMS = frozenset((
     'ascender', 'blueShift', 'capHeight', 'descender', 'hheaAscender',
     'hheaDescender', 'hheaLineGap', 'macintoshFONDFamilyID',
     'openTypeHeadLowestRecPPEM', 'openTypeHheaAscender',
+    'openTypeHheaCaretOffset',
     'openTypeHheaCaretSlopeRise', 'openTypeHheaCaretSlopeRun',
     'openTypeHheaDescender', 'openTypeHheaLineGap',
     'openTypeOS2StrikeoutPosition', 'openTypeOS2StrikeoutSize',

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -122,6 +122,15 @@ class SetCustomParamsTest(unittest.TestCase):
         self.assertEqual(self.ufo.info.postscriptUnderlinePosition, -100)
         self.assertEqual(self.ufo.info.postscriptUnderlineThickness, 50)
 
+    def test_set_codePageRanges(self):
+        set_custom_params(self.ufo, parsed=[('codePageRanges', [1252, 1250])])
+        self.assertEqual(self.ufo.info.openTypeOS2CodePageRanges, [0, 1])
+
+    def test_set_openTypeOS2CodePageRanges(self):
+        set_custom_params(self.ufo, parsed=[
+            ('openTypeOS2CodePageRanges', [0, 1])])
+        self.assertEqual(self.ufo.info.openTypeOS2CodePageRanges, [0, 1])
+
 
 class ParseGlyphsFilterTest(unittest.TestCase):
     def test_complete_parameter(self):


### PR DESCRIPTION
Glyphs.app stores the `codePageRanges` custom parameter as a list of code page numbers, whereas UFO stores the `openTypeOS2CodePageRanges` as a list of bit numbers corresponding to codepages as per OS/2 spec:

https://www.microsoft.com/typography/otspec/os2.htm#cpr

This is the corresponding data file inside the Glyphs.app bundle:
/Applications/Glyphs.app/Contents/Frameworks/GlyphsCore.framework/Versions/A/Resources/CodePageRanges.plist

As for for `openTypeHheaCaretOffset`, it is the only one among the caret-related hhea custom parameters which is not listed in `CUSTOM_INT_PARAMS`. This causes an issue with defcon/ufoLib when setting this custom parameter (as they expects `int` but get `str`).
The other two, `openTypeHheaCaretSlopeRise` and `openTypeHheaCaretSlopeRun` are already in there.