### PR TITLE
Sort generated UFO kerning groups by glyphOrder if present

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -28,7 +28,7 @@ from glyphsLib.parser import Parser
 from glyphsLib.util import write_ufo
 
 
-__version__ = "1.7.5"
+__version__ = "1.7.6.dev0"
 
 __all__ = [
     "build_masters", "build_instances", "load_to_ufos", "load", "loads",

--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -174,8 +174,6 @@ def to_ufos(data, include_instances=False, family_name=None, debug=False):
             # in the font are appended after the listed glyphs, in the order
             # in which they appear in the source file
             glyph_order.append(glyph_name)
-        # unlikely, but you never know...
-        assert glyph_name not in glyphs, "duplicate glyph: %s" % glyph_name
         glyphs[glyph_name] = glyph
 
     loaded_glyphs = set()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.5
+current_version = 1.7.6.dev0
 commit = True
 tag = False
 tag_name = v{new_version}

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name='glyphsLib',
-    version='1.7.5',
+    version='1.7.6.dev0',
     author="James Godfrey-Kittle",
     author_email="jamesgk@google.com",
     description="A bridge from Glyphs source files (.glyphs) to UFOs",


### PR DESCRIPTION
Currently we populate the UFO glyphs in the order in which glyphs are found in the .glyphs source. For the kerning group, we append each new glyph to the respective `leftKerningGroup` and `rightKerningGroup`. 

However, UFO groups (both kerning and not) are stored as arrays of strings in the groups.plist, whereas kerning groups are simply attributes of the glyph objects in Glyphs. Thus, the original ordering of the glyphs from the UFO kerning groups is lost if these were imported in a glyphs file.

Although such order is not relevant to make a kern feature, it's important if one wishes to roundtrip UFO groups.plist -> Glyphs' {left,right}KerningGroup -> UFO groups.plist, and avoid producing spurious changes in the resulting diff.

By using the glyphOrder, we can try to ensure a more predictable order -- provided that the members of the UFO kerning groups also were sorted by 'public.glyphOrder' to begin with.

This patch makes so that when a 'glyphOrder' custom parameter is present, we load the the glyphs data (including left/right kerning group membership) following that order, otherwise we keep using the glyphs data's intrinsic order.