### PR TITLE
Don’t choke on QCURVE

### DIFF
--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -585,7 +585,7 @@ def set_robofont_glyph_background(glyph, key, background):
         points = []
         for x, y, node_type, smooth in path.pop('nodes', []):
             point = {'x': x, 'y': y, 'smooth': smooth}
-            if node_type in ['line', 'curve']:
+            if node_type in ['line', 'curve', 'qcurve']:
                 point['segmentType'] = node_type
             points.append(point)
         contours.append({'points': points})
@@ -833,7 +833,7 @@ def draw_paths(pen, paths):
             # stored at the end of the nodes list.
             nodes.insert(0, nodes.pop())
         for x, y, node_type, smooth in nodes:
-            if node_type not in ['line', 'curve']:
+            if node_type not in ['line', 'curve', 'qcurve']:
                 node_type = None
             pen.addPoint((x, y), segmentType=node_type, smooth=smooth)
         pen.endPath()

--- a/Lib/glyphsLib/casting.py
+++ b/Lib/glyphsLib/casting.py
@@ -207,7 +207,7 @@ class RWNode(RWGlyphs):
     """Read/write a node on an outline."""
 
     _regex = re.compile(
-        '([-.e\d]+) ([-.e\d]+) (LINE|CURVE|OFFCURVE|n/a)(?: (SMOOTH))?')
+        '([-.e\d]+) ([-.e\d]+) (LINE|CURVE|QCURVE|OFFCURVE|n/a)(?: (SMOOTH))?')
 
     def read(self, src):
         """Cast a node from a string with format X Y TYPE [SMOOTH]."""

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -780,6 +780,28 @@ class DrawPathsTest(unittest.TestCase):
         first_segment_type = points[0][2]
         self.assertEqual(first_segment_type, 'curve')
 
+    def test_draw_paths_qcurve(self):
+        contours = [{
+            'closed': True,
+            'nodes': [
+                (143, 695, 'offcurve', False),
+                (37, 593, 'offcurve', False),
+                (37, 434, 'offcurve', False),
+                (143, 334, 'offcurve', False),
+                (223, 334, 'qcurve', True),
+            ]}]
+
+        pen = _PointDataPen()
+        draw_paths(pen, contours)
+
+        points = pen.contours[0]
+
+        first_x, first_y = points[0][:2]
+        self.assertEqual((first_x, first_y), (223, 334))
+
+        first_segment_type = points[0][2]
+        self.assertEqual(first_segment_type, 'qcurve')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/casting_test.py
+++ b/tests/casting_test.py
@@ -17,7 +17,7 @@ from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
 import unittest
-from glyphsLib.casting import cast_data, num, custom_params
+from glyphsLib.casting import cast_data, num, node, custom_params
 from copy import deepcopy
 
 
@@ -73,6 +73,17 @@ class RWNumTest(unittest.TestCase):
         self.assertEqual(num.write(1.0), '1')
         self.assertEqual(num.write(-10), '-10')
         self.assertEqual(num.write(1.1), '1.1')
+
+
+class RWNodeTest(unittest.TestCase):
+
+    def test_read(self):
+        self.assertEqual(node.read('0 0 QCURVE SMOOTH'), [0, 0, 'qcurve', True])
+        self.assertEqual(node.read('0 0 QCURVE'), [0, 0, 'qcurve', False])
+
+    def test_write(self):
+        self.assertEqual(node.write([0, 0, 'qcurve', True]), '0 0 QCURVE SMOOTH')
+        self.assertEqual(node.write([0, 0, 'qcurve', False]), '0 0 QCURVE' )
 
 
 class RWCustomParamsTest(unittest.TestCase):


### PR DESCRIPTION
I’m not entirely sure if this is correct, but it fixes https://github.com/googlei18n/glyphsLib/issues/184 and fontmake can now process the font correctly.