### PR TITLE
Remove shebangs from non-executable modules

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2015 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Lib/glyphsLib/__main__.py
+++ b/Lib/glyphsLib/__main__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2015 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Since these files are not supposed to be executable, there is not point
in having shebangs there. Also, since they just point to the system
python binary, they end up pointing to the wrong python version if both
python2 an python3 packages are installed for one of the python versions.