### PR TITLE
Sort propagated anchors before appending

### DIFF
--- a/Lib/glyphsLib/anchors.py
+++ b/Lib/glyphsLib/anchors.py
@@ -58,7 +58,8 @@ def propagate_glyph_anchors(ufo, parent, processed):
     for component in mark_components:
         adjust_anchors(to_add, ufo, component)
 
-    for name, (x, y) in to_add.items():
+    # we sort propagated anchors to append in a deterministic order
+    for name, (x, y) in sorted(to_add.items()):
         anchor_dict = {'name': name, 'x': x, 'y': y}
         parent.appendAnchor(glyph.anchorClass(anchorDict=anchor_dict))
 

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -359,6 +359,11 @@ class ToUfosTest(unittest.TestCase):
 
         glyph = ufo['dadDotbelow']
         self.assertEqual(len(glyph.anchors), 2)
+        # check propagated anchors are appended in a deterministic order
+        self.assertEqual(
+            [anchor.name for anchor in glyph.anchors],
+            ['bottom', 'top']
+        )
         for anchor in glyph.anchors:
             self.assertEqual(anchor.x, 50)
             if anchor.name == 'bottom':


### PR DESCRIPTION
to ensure we store them in a deterministic order on python3

Fixes #206 