### PR TITLE
[Writer] correctly handle bytes/unicode; dumps return unicode; etc.

### DIFF
--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -21,7 +21,9 @@ from __future__ import (print_function, division, absolute_import,
 import collections
 import unittest
 
-from glyphsLib.parser import Parser
+from fontTools.misc.py23 import unicode, BytesIO, UnicodeIO
+
+from glyphsLib.parser import Parser, Writer
 
 
 class ParserTest(unittest.TestCase):
@@ -55,6 +57,210 @@ class ParserTest(unittest.TestCase):
         self.run_test(
             b'{mystr="Don\xe2\x80\x99t crash";}',
             [('mystr', 'Don’t crash')])
+
+
+class WriterTest(unittest.TestCase):
+
+    SAMPLE_DATA = collections.OrderedDict([
+        ('a', 'b'),
+        (
+            'c', {
+                'd': 'e'
+            }
+        ),
+        (
+            'f', [
+                'g',
+                'h'
+            ]
+        ),
+        ('i', 'j k l')
+    ])
+
+    def test_text_input_output(self):
+        w = Writer(UnicodeIO())
+        w.write(WriterTest.SAMPLE_DATA)
+        result = w.file.getvalue()
+
+        self.assertIsInstance(result, unicode)
+        self.assertEqual(
+            result.split('\n'),
+            [
+                '{',
+                'a = b;',
+                'c = {',
+                'd = e;',
+                '};',
+                'f = (',
+                'g,',
+                'h',
+                ');',
+                'i = "j k l";',
+                '}',
+                ''
+            ])
+
+    def test_text_input_binary_output(self):
+        w = Writer(BytesIO())
+        w.write(WriterTest.SAMPLE_DATA)
+        result = w.file.getvalue()
+
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(
+            result.split(b'\n'),
+            [
+                b'{',
+                b'a = b;',
+                b'c = {',
+                b'd = e;',
+                b'};',
+                b'f = (',
+                b'g,',
+                b'h',
+                b');',
+                b'i = "j k l";',
+                b'}',
+                b''
+            ])
+
+    def test_binary_input_text_output(self):
+        w = Writer(UnicodeIO())
+        w.write({'name': b'\xc3\xbc'})
+        result = w.file.getvalue()
+        # XXX Glyphs.app writes non-ASCII strings unescaped as UTF-8, whereas
+        # glyphsLib currently escapes all non ASCII characters with \\UXXXX.
+        # self.assertEqual(result, '{\nname = "ü";\n}\n')
+        self.assertEqual(result, '{\nname = "\\U00FC";\n}\n')
+
+    def test_indent_0(self):
+        w = Writer(UnicodeIO(), indent=0)
+        w.write(WriterTest.SAMPLE_DATA)
+
+        self.assertEqual(
+            w.file.getvalue().split('\n'),
+            [
+                '{',
+                'a = b;',
+                'c = {',
+                'd = e;',
+                '};',
+                'f = (',
+                'g,',
+                'h',
+                ');',
+                'i = "j k l";',
+                '}',
+                ''
+            ])
+
+    def test_indent_2(self):
+        w = Writer(UnicodeIO(), indent=2)
+        w.write(WriterTest.SAMPLE_DATA)
+
+        self.assertEqual(
+            w.file.getvalue().split('\n'),
+            [
+                '{',
+                '  a = b;',
+                '  c = {',
+                '    d = e;',
+                '  };',
+                '  f = (',
+                '    g,',
+                '    h',
+                '  );',
+                '  i = "j k l";',
+                '}',
+                ''
+            ])
+
+    def test_indent_4(self):
+        w = Writer(UnicodeIO(), indent=4)
+        w.write(WriterTest.SAMPLE_DATA)
+
+        self.assertEqual(
+            w.file.getvalue().split('\n'),
+            [
+                '{',
+                '    a = b;',
+                '    c = {',
+                '        d = e;',
+                '    };',
+                '    f = (',
+                '        g,',
+                '        h',
+                '    );',
+                '    i = "j k l";',
+                '}',
+                ''
+            ])
+
+    def test_indent_tab(self):
+        w = Writer(UnicodeIO(), indent='\t')
+        w.write(WriterTest.SAMPLE_DATA)
+
+        self.assertEqual(
+            w.file.getvalue().split('\n'),
+            [
+                '{',
+                '\ta = b;',
+                '\tc = {',
+                '\t\td = e;',
+                '\t};',
+                '\tf = (',
+                '\t\tg,',
+                '\t\th',
+                '\t);',
+                '\ti = "j k l";',
+                '}',
+                ''
+            ])
+
+    def test_sort_keys(self):
+        data = dict(WriterTest.SAMPLE_DATA)
+        del data['a']
+        data['b'] = 'a'
+
+        w = Writer(UnicodeIO(), sort_keys=True)
+        w.write(data)
+
+        self.assertEqual(
+            w.file.getvalue().split('\n'),
+            [
+                '{',
+                'b = a;',
+                'c = {',
+                'd = e;',
+                '};',
+                'f = (',
+                'g,',
+                'h',
+                ');',
+                'i = "j k l";',
+                '}',
+                ''
+            ])
+
+    def test_escape_octal(self):
+        w = Writer(UnicodeIO())
+        w.write({'CR': '\u000D'})
+
+        self.assertEqual(w.file.getvalue(), '{\nCR = "\\015";\n}\n')
+
+    def test_escape_inner_quotes(self):
+        w = Writer(UnicodeIO())
+        w.write({'s': 'string with inner "quotes"'})
+
+        self.assertEqual(
+            w.file.getvalue(),
+            '{\ns = "string with inner \\"quotes\\"";\n}\n')
+
+    def test_no_escape(self):
+        s = '"quoted string with escaped inner \\"quotes\\""'
+        w = Writer(UnicodeIO(), escape=False)
+        w.write({'s': s})
+
+        self.assertEqual(w.file.getvalue(), '{\ns = %s;\n}\n' % s)
 
 
 if __name__ == '__main__':

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -78,10 +78,9 @@ class WriterTest(unittest.TestCase):
     ])
 
     def test_text_input_output(self):
-        f = UnicodeIO()
-        w = Writer()
-        w.write(WriterTest.SAMPLE_DATA, f)
-        result = f.getvalue()
+        w = Writer(UnicodeIO())
+        w.write(WriterTest.SAMPLE_DATA)
+        result = w.file.getvalue()
 
         self.assertIsInstance(result, unicode)
         self.assertEqual(
@@ -102,10 +101,9 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_text_input_binary_output(self):
-        f = BytesIO()
-        w = Writer()
-        w.write(WriterTest.SAMPLE_DATA, f)
-        result = f.getvalue()
+        w = Writer(BytesIO())
+        w.write(WriterTest.SAMPLE_DATA)
+        result = w.file.getvalue()
 
         self.assertIsInstance(result, bytes)
         self.assertEqual(
@@ -126,22 +124,20 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_binary_input_text_output(self):
-        f = UnicodeIO()
-        w = Writer()
-        w.write({'name': b'\xc3\xbc'}, f)
-        result = f.getvalue()
+        w = Writer(UnicodeIO())
+        w.write({'name': b'\xc3\xbc'})
+        result = w.file.getvalue()
         # XXX Glyphs.app writes non-ASCII strings unescaped as UTF-8, whereas
         # glyphsLib currently escapes all non ASCII characters with \\UXXXX.
         # self.assertEqual(result, '{\nname = "ü";\n}\n')
         self.assertEqual(result, '{\nname = "\\U00FC";\n}\n')
 
     def test_indent_0(self):
-        f = UnicodeIO()
-        w = Writer(indent=0)
-        w.write(WriterTest.SAMPLE_DATA, f)
+        w = Writer(UnicodeIO(), indent=0)
+        w.write(WriterTest.SAMPLE_DATA)
 
         self.assertEqual(
-            f.getvalue().split('\n'),
+            w.file.getvalue().split('\n'),
             [
                 '{',
                 'a = b;',
@@ -158,12 +154,11 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_indent_2(self):
-        f = UnicodeIO()
-        w = Writer(indent=2)
-        w.write(WriterTest.SAMPLE_DATA, f)
+        w = Writer(UnicodeIO(), indent=2)
+        w.write(WriterTest.SAMPLE_DATA)
 
         self.assertEqual(
-            f.getvalue().split('\n'),
+            w.file.getvalue().split('\n'),
             [
                 '{',
                 '  a = b;',
@@ -180,12 +175,11 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_indent_4(self):
-        f = UnicodeIO()
-        w = Writer(indent=4)
-        w.write(WriterTest.SAMPLE_DATA, f)
+        w = Writer(UnicodeIO(), indent=4)
+        w.write(WriterTest.SAMPLE_DATA)
 
         self.assertEqual(
-            f.getvalue().split('\n'),
+            w.file.getvalue().split('\n'),
             [
                 '{',
                 '    a = b;',
@@ -202,12 +196,11 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_indent_tab(self):
-        f = UnicodeIO()
-        w = Writer(indent='\t')
-        w.write(WriterTest.SAMPLE_DATA, f)
+        w = Writer(UnicodeIO(), indent='\t')
+        w.write(WriterTest.SAMPLE_DATA)
 
         self.assertEqual(
-            f.getvalue().split('\n'),
+            w.file.getvalue().split('\n'),
             [
                 '{',
                 '\ta = b;',
@@ -228,12 +221,11 @@ class WriterTest(unittest.TestCase):
         del data['a']
         data['b'] = 'a'
 
-        f = UnicodeIO()
-        w = Writer(sort_keys=True)
-        w.write(data, f)
+        w = Writer(UnicodeIO(), sort_keys=True)
+        w.write(data)
 
         self.assertEqual(
-            f.getvalue().split('\n'),
+            w.file.getvalue().split('\n'),
             [
                 '{',
                 'b = a;',
@@ -250,28 +242,25 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_escape_octal(self):
-        f = UnicodeIO()
-        w = Writer()
-        w.write({'CR': '\u000D'}, f)
+        w = Writer(UnicodeIO())
+        w.write({'CR': '\u000D'})
 
-        self.assertEqual(f.getvalue(), '{\nCR = "\\015";\n}\n')
+        self.assertEqual(w.file.getvalue(), '{\nCR = "\\015";\n}\n')
 
     def test_escape_inner_quotes(self):
-        f = UnicodeIO()
-        w = Writer()
-        w.write({'s': 'string with inner "quotes"'}, f)
+        w = Writer(UnicodeIO())
+        w.write({'s': 'string with inner "quotes"'})
 
         self.assertEqual(
-            f.getvalue(),
+            w.file.getvalue(),
             '{\ns = "string with inner \\"quotes\\"";\n}\n')
 
     def test_no_escape(self):
         s = '"quoted string with escaped inner \\"quotes\\""'
-        f = UnicodeIO()
-        w = Writer(escape=False)
-        w.write({'s': s}, f)
+        w = Writer(UnicodeIO(), escape=False)
+        w.write({'s': s})
 
-        self.assertEqual(f.getvalue(), '{\ns = %s;\n}\n' % s)
+        self.assertEqual(w.file.getvalue(), '{\ns = %s;\n}\n' % s)
 
 
 if __name__ == '__main__':

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -127,10 +127,7 @@ class WriterTest(unittest.TestCase):
         w = Writer(UnicodeIO())
         w.write({'name': b'\xc3\xbc'})
         result = w.file.getvalue()
-        # XXX Glyphs.app writes non-ASCII strings unescaped as UTF-8, whereas
-        # glyphsLib currently escapes all non ASCII characters with \\UXXXX.
-        # self.assertEqual(result, '{\nname = "ü";\n}\n')
-        self.assertEqual(result, '{\nname = "\\U00FC";\n}\n')
+        self.assertEqual(result, '{\nname = "ü";\n}\n')
 
     def test_indent_0(self):
         w = Writer(UnicodeIO(), indent=0)
@@ -261,6 +258,12 @@ class WriterTest(unittest.TestCase):
         w.write({'s': s})
 
         self.assertEqual(w.file.getvalue(), '{\ns = %s;\n}\n' % s)
+
+    def test_ensure_ascii(self):
+        w = Writer(UnicodeIO(), ensure_ascii=True)
+        w.write({'s': 'a \n \t ü'})
+        result = w.file.getvalue()
+        self.assertEqual(result, '{\ns = "a \\012 \t \\U00FC";\n}\n')
 
 
 if __name__ == '__main__':

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -78,9 +78,10 @@ class WriterTest(unittest.TestCase):
     ])
 
     def test_text_input_output(self):
-        w = Writer(UnicodeIO())
-        w.write(WriterTest.SAMPLE_DATA)
-        result = w.file.getvalue()
+        f = UnicodeIO()
+        w = Writer()
+        w.write(WriterTest.SAMPLE_DATA, f)
+        result = f.getvalue()
 
         self.assertIsInstance(result, unicode)
         self.assertEqual(
@@ -101,9 +102,10 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_text_input_binary_output(self):
-        w = Writer(BytesIO())
-        w.write(WriterTest.SAMPLE_DATA)
-        result = w.file.getvalue()
+        f = BytesIO()
+        w = Writer()
+        w.write(WriterTest.SAMPLE_DATA, f)
+        result = f.getvalue()
 
         self.assertIsInstance(result, bytes)
         self.assertEqual(
@@ -124,20 +126,22 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_binary_input_text_output(self):
-        w = Writer(UnicodeIO())
-        w.write({'name': b'\xc3\xbc'})
-        result = w.file.getvalue()
+        f = UnicodeIO()
+        w = Writer()
+        w.write({'name': b'\xc3\xbc'}, f)
+        result = f.getvalue()
         # XXX Glyphs.app writes non-ASCII strings unescaped as UTF-8, whereas
         # glyphsLib currently escapes all non ASCII characters with \\UXXXX.
         # self.assertEqual(result, '{\nname = "ü";\n}\n')
         self.assertEqual(result, '{\nname = "\\U00FC";\n}\n')
 
     def test_indent_0(self):
-        w = Writer(UnicodeIO(), indent=0)
-        w.write(WriterTest.SAMPLE_DATA)
+        f = UnicodeIO()
+        w = Writer(indent=0)
+        w.write(WriterTest.SAMPLE_DATA, f)
 
         self.assertEqual(
-            w.file.getvalue().split('\n'),
+            f.getvalue().split('\n'),
             [
                 '{',
                 'a = b;',
@@ -154,11 +158,12 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_indent_2(self):
-        w = Writer(UnicodeIO(), indent=2)
-        w.write(WriterTest.SAMPLE_DATA)
+        f = UnicodeIO()
+        w = Writer(indent=2)
+        w.write(WriterTest.SAMPLE_DATA, f)
 
         self.assertEqual(
-            w.file.getvalue().split('\n'),
+            f.getvalue().split('\n'),
             [
                 '{',
                 '  a = b;',
@@ -175,11 +180,12 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_indent_4(self):
-        w = Writer(UnicodeIO(), indent=4)
-        w.write(WriterTest.SAMPLE_DATA)
+        f = UnicodeIO()
+        w = Writer(indent=4)
+        w.write(WriterTest.SAMPLE_DATA, f)
 
         self.assertEqual(
-            w.file.getvalue().split('\n'),
+            f.getvalue().split('\n'),
             [
                 '{',
                 '    a = b;',
@@ -196,11 +202,12 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_indent_tab(self):
-        w = Writer(UnicodeIO(), indent='\t')
-        w.write(WriterTest.SAMPLE_DATA)
+        f = UnicodeIO()
+        w = Writer(indent='\t')
+        w.write(WriterTest.SAMPLE_DATA, f)
 
         self.assertEqual(
-            w.file.getvalue().split('\n'),
+            f.getvalue().split('\n'),
             [
                 '{',
                 '\ta = b;',
@@ -221,11 +228,12 @@ class WriterTest(unittest.TestCase):
         del data['a']
         data['b'] = 'a'
 
-        w = Writer(UnicodeIO(), sort_keys=True)
-        w.write(data)
+        f = UnicodeIO()
+        w = Writer(sort_keys=True)
+        w.write(data, f)
 
         self.assertEqual(
-            w.file.getvalue().split('\n'),
+            f.getvalue().split('\n'),
             [
                 '{',
                 'b = a;',
@@ -242,25 +250,28 @@ class WriterTest(unittest.TestCase):
             ])
 
     def test_escape_octal(self):
-        w = Writer(UnicodeIO())
-        w.write({'CR': '\u000D'})
+        f = UnicodeIO()
+        w = Writer()
+        w.write({'CR': '\u000D'}, f)
 
-        self.assertEqual(w.file.getvalue(), '{\nCR = "\\015";\n}\n')
+        self.assertEqual(f.getvalue(), '{\nCR = "\\015";\n}\n')
 
     def test_escape_inner_quotes(self):
-        w = Writer(UnicodeIO())
-        w.write({'s': 'string with inner "quotes"'})
+        f = UnicodeIO()
+        w = Writer()
+        w.write({'s': 'string with inner "quotes"'}, f)
 
         self.assertEqual(
-            w.file.getvalue(),
+            f.getvalue(),
             '{\ns = "string with inner \\"quotes\\"";\n}\n')
 
     def test_no_escape(self):
         s = '"quoted string with escaped inner \\"quotes\\""'
-        w = Writer(UnicodeIO(), escape=False)
-        w.write({'s': s})
+        f = UnicodeIO()
+        w = Writer(escape=False)
+        w.write({'s': s}, f)
 
-        self.assertEqual(w.file.getvalue(), '{\ns = %s;\n}\n' % s)
+        self.assertEqual(f.getvalue(), '{\ns = %s;\n}\n' % s)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- `Writer.write` now accepts either unicode strings or bytes string; the latter are decoded as UTF-8 internally.
- If the file object accepts bytes (i.e. is opened in binary mode), the unicode strings are encoded to UTF-8 via `codecs.StreamWriter`.
- If the file object already accepts unicodes, it is used directly without the codecs wrapper.

Other changes:
- `dumps` function now always return a unicode string, for consistency with python3 json module.
- in `Writer.__init__` the `out` argument (renamed `fp`) no longer defaults to `sys.stdout`, it's now a required positional argument (like in the `dump` function).
- make the `indent` argument behave like in json dump/dumps: ie. accept either an int or a string (e.g. `indent="\t"`).
- use same method that fonttools `XMLWriter` uses to make sure that the indentation whitespace is only written once per line (see `self._needindent` flag).
- pass `**kwargs` from `load` and `loads` functions down to `Parser` instance, like `dump`  and `dumps` do with `Writer`.