### PR TITLE
Allow interpolating instances with non rounded geometry

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -97,7 +97,8 @@ def build_masters(filename, master_dir, designspace_instance_dir=None,
         return ufos
 
 
-def build_instances(filename, master_dir, instance_dir, family_name=None):
+def build_instances(filename, master_dir, instance_dir, family_name=None,
+                    round_geometry=True):
     """Write and return UFOs from the instances defined in a .glyphs file.
 
     Args:
@@ -110,5 +111,6 @@ def build_instances(filename, master_dir, instance_dir, family_name=None):
     master_ufos, instance_data = load_to_ufos(
         filename, include_instances=True, family_name=family_name)
     instance_ufos = interpolate(
-        master_ufos, master_dir, instance_dir, instance_data)
+        master_ufos, master_dir, instance_dir, instance_data,
+        round_geometry=round_geometry)
     return instance_ufos

--- a/Lib/glyphsLib/__main__.py
+++ b/Lib/glyphsLib/__main__.py
@@ -41,6 +41,8 @@ def parse_options(args):
                         help="Output and generate interpolated instances UFO "
                              "to folder INSTANCES. "
                              "(default: %(const)s)")
+    parser.add_argument("-R", "--no-round", action="store_false",
+                        help="Round geometry to integers")
     options = parser.parse_args(args)
     return options
 
@@ -51,7 +53,8 @@ def main(args=None):
         if opt.instances is None:
             glyphsLib.build_masters(opt.glyphs, opt.masters)
         else:
-            glyphsLib.build_instances(opt.glyphs, opt.masters, opt.instances)
+            glyphsLib.build_instances(opt.glyphs, opt.masters, opt.instances,
+                                      round_geometry=opt.no_round)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -73,7 +73,8 @@ WIDTH_CODES = {
 }
 
 
-def interpolate(ufos, master_dir, out_dir, instance_data, debug=False):
+def interpolate(ufos, master_dir, out_dir, instance_data, debug=False,
+                round_geometry=True):
     """Create MutatorMath designspace and generate instances.
     Returns instance UFOs, or unused instance data if debug is True.
     """
@@ -85,7 +86,8 @@ def interpolate(ufos, master_dir, out_dir, instance_data, debug=False):
     logger.info('Building instances')
     for path, _ in instance_files:
         clean_ufo(path)
-    build(designspace_path, outputUFOFormatVersion=3)
+    build(designspace_path, outputUFOFormatVersion=3,
+          roundGeometry=round_geometry)
 
     instance_ufos = apply_instance_data(instance_files)
     if debug:


### PR DESCRIPTION
When interpolating instances one may want to not round values to integers.

This can be useful when adding masters to a designspace without piling up rounding differences.
For example, if  you have 4 masters and a bunch of instances in between:
```
A-B
| |
C-D
```
And you want to interpolate new masters where instances W, X, Y, Z and R were:
```
A--W--B
|  |  |
X--R--Z
|  |  |
C--Y--D
```
You do not want to round to integers in those new masters otherwise the other instances will be too different from the original 4-master instances. Say an instance interpolated between A and B will be different from an instance interpolated between A and rounded-W or rounded-W and B, whereas it will be closer to that instance interpolated between A and non-rounded-W or non-rounded-W and B.