### PR TITLE
Roundtrip .glyphs -> objects -> .glyphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ dist
 
 # Autosaved files
 *~
+
+# Additional test files
+# (there's a script to download them from GitHub)
+tests/noto-source

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist
 # Unit test
 .cache/
 .tox/
+.coverage
+htmlcov
 
 # Autosaved files
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ htmlcov
 
 # Additional test files
 # (there's a script to download them from GitHub)
-tests/noto-source
+tests/noto-source*

--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -58,13 +58,6 @@ def loads(s):
     return data
 
 
-def normalize(value):
-    """Read a .glyphs file from a bytes object.
-    Return a bytes object with the file's contents, normalized:
-    dictionary keys are put in order.
-    """
-    pass
-
 def load_to_ufos(file_or_path, include_instances=False, family_name=None,
                  debug=False):
     """Load an unpacked .glyphs object to UFO objects."""

--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -58,6 +58,13 @@ def loads(s):
     return data
 
 
+def normalize(value):
+    """Read a .glyphs file from a bytes object.
+    Return a bytes object with the file's contents, normalized:
+    dictionary keys are put in order.
+    """
+    pass
+
 def load_to_ufos(file_or_path, include_instances=False, family_name=None,
                  debug=False):
     """Load an unpacked .glyphs object to UFO objects."""

--- a/Lib/glyphsLib/builder/__init__.py
+++ b/Lib/glyphsLib/builder/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .glyphs import to_glyphs
+
+from .ufo import to_ufos, logger

--- a/Lib/glyphsLib/builder/constants.py
+++ b/Lib/glyphsLib/builder/constants.py
@@ -1,0 +1,74 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PUBLIC_PREFIX = 'public.'
+GLYPHS_PREFIX = 'com.schriftgestaltung.'
+GLYPHLIB_PREFIX = GLYPHS_PREFIX + 'Glyphs.'
+ROBOFONT_PREFIX = 'com.typemytype.robofont.'
+UFO2FT_FILTERS_KEY = 'com.github.googlei18n.ufo2ft.filters'
+
+GLYPHS_COLORS = (
+    '0.85,0.26,0.06,1',
+    '0.99,0.62,0.11,1',
+    '0.65,0.48,0.2,1',
+    '0.97,1,0,1',
+    '0.67,0.95,0.38,1',
+    '0.04,0.57,0.04,1',
+    '0,0.67,0.91,1',
+    '0.18,0.16,0.78,1',
+    '0.5,0.09,0.79,1',
+    '0.98,0.36,0.67,1',
+    '0.75,0.75,0.75,1',
+    '0.25,0.25,0.25,1')
+
+# https://www.microsoft.com/typography/otspec/os2.htm#cpr
+CODEPAGE_RANGES = {
+    1252: 0,
+    1250: 1,
+    1251: 2,
+    1253: 3,
+    1254: 4,
+    1255: 5,
+    1256: 6,
+    1257: 7,
+    1258: 8,
+    # 9-15: Reserved for Alternate ANSI
+    874: 16,
+    932: 17,
+    936: 18,
+    949: 19,
+    950: 20,
+    1361: 21,
+    # 22-28: Reserved for Alternate ANSI and OEM
+    # 29: Macintosh Character Set (US Roman)
+    # 30: OEM Character Set
+    # 31: Symbol Character Set
+    # 32-47: Reserved for OEM
+    869: 48,
+    866: 49,
+    865: 50,
+    864: 51,
+    863: 52,
+    862: 53,
+    861: 54,
+    860: 55,
+    857: 56,
+    855: 57,
+    852: 58,
+    775: 59,
+    737: 60,
+    708: 61,
+    850: 62,
+    437: 63,
+}

--- a/Lib/glyphsLib/builder/glyphs.py
+++ b/Lib/glyphsLib/builder/glyphs.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from glyphsLib import classes
-from glyphsLib import builder
+
+from .constants import GLYPHS_PREFIX
 
 # def designspace_from_ufos(ufos):
 #     pass
@@ -47,5 +48,5 @@ def to_glyphs_master(ufo):
     Extract from the given UFO the data that goes into a GSFontMaster.
     """
     master = classes.GSFontMaster()
-    master.id = ufo.lib[builder.GLYPHS_PREFIX + 'fontMasterID']
+    master.id = ufo.lib[GLYPHS_PREFIX + 'fontMasterID']
     return master

--- a/Lib/glyphsLib/builder/ufo.py
+++ b/Lib/glyphsLib/builder/ufo.py
@@ -177,7 +177,7 @@ def generate_base_fonts(font, family_name):
     date_created = getattr(font, 'date', None)
     if date_created is not None:
         date_created = to_ufo_time(date_created)
-    units_per_em = font.unitsPerEm
+    units_per_em = font.upm
     version_major = font.versionMajor
     version_minor = font.versionMinor
     user_data = font.userData
@@ -232,7 +232,7 @@ def generate_base_fonts(font, family_name):
 
         width = master.width
         weight = master.weight
-        custom = master.custom
+        custom = master.customName
         if weight:
             ufo.lib[GLYPHS_PREFIX + 'weight'] = weight
         if width:
@@ -522,7 +522,7 @@ def set_blue_values(ufo, alignment_zones):
 
 def set_guidelines(ufo_obj, glyphs_data):
     """Set guidelines."""
-    guidelines = glyphs_data.guideLines
+    guidelines = glyphs_data.guides
     if not guidelines:
         return
     new_guidelines = []

--- a/Lib/glyphsLib/builder/ufo.py
+++ b/Lib/glyphsLib/builder/ufo.py
@@ -25,74 +25,20 @@ from collections import deque
 from glyphsLib.anchors import propagate_font_anchors
 from glyphsLib.util import clear_data, cast_to_number_or_bool, bin_to_int_list
 import glyphsLib.glyphdata
+from .constants import (
+    PUBLIC_PREFIX,
+    GLYPHS_PREFIX,
+    GLYPHLIB_PREFIX,
+    ROBOFONT_PREFIX,
+    UFO2FT_FILTERS_KEY,
+    GLYPHS_COLORS,
+    CODEPAGE_RANGES, )
 
 __all__ = [
     'to_ufos', 'set_custom_params', 'GLYPHS_PREFIX',
 ]
 
 logger = logging.getLogger(__name__)
-
-
-PUBLIC_PREFIX = 'public.'
-GLYPHS_PREFIX = 'com.schriftgestaltung.'
-GLYPHLIB_PREFIX = GLYPHS_PREFIX + 'Glyphs.'
-ROBOFONT_PREFIX = 'com.typemytype.robofont.'
-UFO2FT_FILTERS_KEY = 'com.github.googlei18n.ufo2ft.filters'
-
-GLYPHS_COLORS = (
-    '0.85,0.26,0.06,1',
-    '0.99,0.62,0.11,1',
-    '0.65,0.48,0.2,1',
-    '0.97,1,0,1',
-    '0.67,0.95,0.38,1',
-    '0.04,0.57,0.04,1',
-    '0,0.67,0.91,1',
-    '0.18,0.16,0.78,1',
-    '0.5,0.09,0.79,1',
-    '0.98,0.36,0.67,1',
-    '0.75,0.75,0.75,1',
-    '0.25,0.25,0.25,1')
-
-# https://www.microsoft.com/typography/otspec/os2.htm#cpr
-CODEPAGE_RANGES = {
-    1252: 0,
-    1250: 1,
-    1251: 2,
-    1253: 3,
-    1254: 4,
-    1255: 5,
-    1256: 6,
-    1257: 7,
-    1258: 8,
-    # 9-15: Reserved for Alternate ANSI
-    874: 16,
-    932: 17,
-    936: 18,
-    949: 19,
-    950: 20,
-    1361: 21,
-    # 22-28: Reserved for Alternate ANSI and OEM
-    # 29: Macintosh Character Set (US Roman)
-    # 30: OEM Character Set
-    # 31: Symbol Character Set
-    # 32-47: Reserved for OEM
-    869: 48,
-    866: 49,
-    865: 50,
-    864: 51,
-    863: 52,
-    862: 53,
-    861: 54,
-    860: 55,
-    857: 56,
-    855: 57,
-    852: 58,
-    775: 59,
-    737: 60,
-    708: 61,
-    850: 62,
-    437: 63,
-}
 
 
 def to_ufos(font, include_instances=False, family_name=None, debug=False):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -939,7 +939,7 @@ class UserDataProxy(Proxy):
             del self._owner._userData[key]
 
     def __contains__(self, item):
-        return item in self._owner._userData.values()
+        return item in self._owner._userData
 
     def __iter__(self):
         for value in self._owner._userData.values():
@@ -2299,7 +2299,6 @@ class GSLayer(GSBase):
         "visible": bool,
         "width": float,
         "widthMetricsKey": unicode,
-        "smartComponentPoleMapping": dict,
     }
     _defaultsForName = {
         "weight": 600,
@@ -2329,9 +2328,6 @@ class GSLayer(GSBase):
         "vertWidth",
         "width",
     )
-    # FIXME: (jany) with the line below, user data would be shared between all
-    #   instances of GSLayer!?
-    # _userData = {}
 
     def __init__(self):
         super(GSLayer, self).__init__()
@@ -2341,7 +2337,6 @@ class GSLayer(GSBase):
         self.guides = []
         self._paths = []
         self._selection = []
-        self.smartComponentPoleMapping = {}
         self._userData = {}
 
     def __repr__(self):
@@ -2414,6 +2409,16 @@ class GSLayer(GSBase):
     userData = property(
         lambda self: UserDataProxy(self),
         lambda self, value: UserDataProxy(self).setter(value))
+
+    @property
+    def smartComponentPoleMapping(self):
+        if "PartSelection" not in self.userData:
+            self.userData["PartSelection"] = {}
+        return self.userData["PartSelection"]
+
+    @smartComponentPoleMapping.setter
+    def smartComponentPoleMapping(self, value):
+        self.userData["PartSelection"] = value
 
     @property
     def bounds(self):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1010,7 +1010,7 @@ class GSCustomParameter(GSBase):
         'underlinePosition', 'underlineThickness', 'unitsPerEm',
         'vheaVertAscender',
         'vheaVertDescender', 'vheaVertLineGap', 'weightClass', 'widthClass',
-        'winAscent', 'winDescent', 'xHeight', 'year', 'Grid Spacing'))
+        'winAscent', 'winDescent', 'year', 'Grid Spacing'))
     _CUSTOM_FLOAT_PARAMS = frozenset((
         'postscriptBlueScale',))
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2064,7 +2064,7 @@ class GSInstance(GSBase):
     _classesForName = {
         "customParameters": GSCustomParameter,
         "exports": bool,
-        "instanceInterpolations": OrderedDict,
+        "instanceInterpolations": dict,
         "interpolationCustom": float,
         "interpolationCustom1": float,
         "interpolationCustom2": float,
@@ -2677,6 +2677,7 @@ class GSFont(GSBase):
         "gridSubDivision": 1,
         "unitsPerEm": 1000,
         "kerning": OrderedDict(),
+        "keyboardIncrement": 1,
     }
 
     def __init__(self, path=None):
@@ -2693,7 +2694,6 @@ class GSFont(GSBase):
         self._classes = []
         self.filepath = None
         self._userData = None
-        self.keyboardIncrement = None
 
         if path:
             assert isinstance(path, (str, unicode)), \
@@ -2712,7 +2712,7 @@ class GSFont(GSBase):
         return "<%s \"%s\">" % (self.__class__.__name__, self.familyName)
 
     def shouldWriteValueForKey(self, key):
-        if key in ("unitsPerEm", "versionMinor", "keyboardIncrement"):
+        if key in ("unitsPerEm", "versionMinor"):
             return True
         return super(GSFont, self).shouldWriteValueForKey(key)
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -828,6 +828,13 @@ class LayerPathsProxy(IndexedObjectsProxy):
         super(LayerPathsProxy, self).__init__(owner)
 
 
+class LayerHintsProxy(IndexedObjectsProxy):
+    _objects_name = "_hints"
+
+    def __init__(self, owner):
+        super(LayerHintsProxy, self).__init__(owner)
+
+
 class LayerComponentsProxy(IndexedObjectsProxy):
     _objects_name = "_components"
 
@@ -1962,12 +1969,16 @@ class GSHint(GSBase):
         else:
             return "<GSHint %s %s>" % (self.type, direction)
 
+    @property
+    def parent(self):
+        return self._parent
+
     def _find_node_by_indices(self, point):
         """"Find the GSNode that is refered to by the given indices."""
         path_index, node_index = point
-        layer = self.parent  # FIXME: (jany) I don't have access to the parent from the GSHint!!!
-        path = layer.paths[path_index]
-        node = path.nodes[node_index]
+        layer = self.parent
+        path = layer.paths[int(path_index)]
+        node = path.nodes[int(node_index)]
         return node
 
     def _find_indices_for_node(self, node):
@@ -2449,6 +2460,7 @@ class GSLayer(GSBase):
     def __init__(self):
         super(GSLayer, self).__init__()
         self._anchors = []
+        self._hints = []
         self._annotations = []
         self._components = []
         self.guides = []
@@ -2506,6 +2518,10 @@ class GSLayer(GSBase):
     anchors = property(
         lambda self: LayerAnchorsProxy(self),
         lambda self, value: LayerAnchorsProxy(self).setter(value))
+
+    hints = property(
+        lambda self: LayerHintsProxy(self),
+        lambda self, value: LayerHintsProxy(self).setter(value))
 
     paths = property(
         lambda self: LayerPathsProxy(self),

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1249,6 +1249,8 @@ class GSFontMaster(GSBase):
         self.italicAngle = 0.0
         self.customValue = 0.0
         self._userData = None
+        self.xHeight = None
+        self.capHeight = None
 
     def __repr__(self):
         return '<GSFontMaster "%s" width %s weight %s>' % \
@@ -1258,6 +1260,9 @@ class GSFontMaster(GSBase):
         if key in ("width", "weight"):
             if getattr(self, key) == "Regular":
                 return False
+            return True
+        if key in ("xHeight", "capHeight") and getattr(self, key) is not None:
+            # Write those values even when == 0
             return True
         return super(GSFontMaster, self).shouldWriteValueForKey(key)
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -23,7 +23,7 @@ import glyphsLib
 from glyphsLib.types import (
     transform, point, rect, size, glyphs_datetime, color, floatToString,
     readIntlist, writeIntlist, needsQuotes, feature_syntax_encode, baseType,
-    encode_dict_as_string_for_gsnode
+    encode_dict_as_string_for_gsnode, decode_dict_as_string_from_gsnode
 )
 from glyphsLib.parser import Parser
 from glyphsLib.writer import GlyphsWriter
@@ -1405,8 +1405,9 @@ class GSNode(GSBase):
 
         # TODO: Use proper string parsing used in other classes
         if '{\\nname' in line:
-            nameMatch = re.match(r'\{\\nname = "?(.+?)"?;\\n\}', m[4]).groups()
-            self.name = nameMatch[0]
+            parser = Parser()
+            value = decode_dict_as_string_from_gsnode(m[4])
+            self.name = parser.parse(value)["name"]
         else:
             self.name = None
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2059,7 +2059,7 @@ class GSInstance(GSBase):
     _classesForName = {
         "customParameters": GSCustomParameter,
         "exports": bool,
-        "instanceInterpolations": dict,
+        "instanceInterpolations": OrderedDict,
         "interpolationCustom": float,
         "interpolationCustom1": float,
         "interpolationCustom2": float,
@@ -2644,6 +2644,7 @@ class GSFont(GSBase):
         "instances": GSInstance,
         "keepAlternatesTogether": bool,
         "kerning": OrderedDict,
+        "keyboardIncrement": float,
         "manufacturer": unicode,
         "manufacturerURL": unicode,
         "unitsPerEm": int,
@@ -2700,7 +2701,7 @@ class GSFont(GSBase):
         return "<%s \"%s\">" % (self.__class__.__name__, self.familyName)
 
     def shouldWriteValueForKey(self, key):
-        if key in ("unitsPerEm", "versionMinor"):
+        if key in ("unitsPerEm", "versionMinor", "keyboardIncrement"):
             return True
         return super(GSFont, self).shouldWriteValueForKey(key)
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1924,22 +1924,23 @@ class GSHint(GSBase):
         if key == "stem":
             if self.stem == -2:
                 return None
-        if key in ['origin', 'other1', 'other2', 'place', 'scale'] and getattr(self, key).value == getattr(self, key).default:
+        if (key in ['origin', 'other1', 'other2', 'place', 'scale'] and
+                getattr(self, key).value == getattr(self, key).default):
             return None
         if key == "settings" and (self.settings is None or len(self.settings) == 0):
             return None
         return super(GSHint, self).shouldWriteValueForKey(key)
 
-    def Hint__origin__pos(self):
-        if (self.originNode):
+    def _origin_pos(self):
+        if self.originNode:
             if self.horizontal:
                 return self.originNode.position.y
             else:
                 return self.originNode.position.x
         return self.origin
 
-    def Hint__width__pos(self):
-        if (self.targetNode):
+    def _width_pos(self):
+        if self.targetNode:
             if self.horizontal:
                 return self.targetNode.position.y
             else:
@@ -1952,25 +1953,40 @@ class GSHint(GSBase):
         else:
             direction = "vertical"
         if self.type == 'BOTTOMGHOST' or self.type == 'TOPGHOST':
-            return "<GSHint %s origin=(%s)>" % (self.type, self.Hint__origin__pos())
+            return "<GSHint %s origin=(%s)>" % (self.type, self._origin_pos())
         elif self.type == 'STEM':
-            return "<GSHint %s Stem origin=(%s) target=(%s) %s>" % (direction, self.Hint__origin__pos(), self.Hint__width__pos())
+            return "<GSHint %s Stem origin=(%s) target=(%s) %s>" % (
+                direction, self._origin_pos(), self._width_pos())
         elif self.type == 'CORNER' or self.type == 'CAP':
             return "<GSHint %s %s>" % (self.type, self.name)
         else:
             return "<GSHint %s %s>" % (self.type, direction)
+
+    def _find_node_by_indices(self, point):
+        """"Find the GSNode that is refered to by the given indices."""
+        path_index, node_index = point
+        layer = self.parent  # FIXME: (jany) I don't have access to the parent from the GSHint!!!
+        path = layer.paths[path_index]
+        node = path.nodes[node_index]
+        return node
+
+    def _find_indices_for_node(self, node):
+        """Find the path_index and node_index that identify the given node."""
+        path = node.parent
+        layer = path.parent
+        for path_index in range(len(layer.paths)):
+            if path == layer.paths[path_index]:
+                for node_index in range(len(path.nodes)):
+                    if node == path.nodes[node_index]:
+                        return point(path_index, node_index)
+        return None
 
     @property
     def originNode(self):
         if self._originNode is not None:
             return self._originNode
         if self._origin is not None:
-            # Find the GSNode that is refered to by the indices in _origin
-            path_index, node_index = self._origin
-            layer = self.parent  # FIXME: (jany) I don't have access to the parent from the GSHint!!!
-            path = layer.paths[path_index]
-            node = path.nodes[node_index]
-            return node
+            return self._find_node_by_indices(self._origin)
 
     @originNode.setter
     def originNode(self, node):
@@ -1982,22 +1998,84 @@ class GSHint(GSBase):
         if self._origin is not None:
             return self._origin
         if self._originNode is not None:
-            # Find the path_index & node_index of the _originNode
-            path = self._originNode.parent
-            layer = path.parent
-            for path_index in range(len(layer.paths)):
-                if path == layer.paths[path_index]:
-                    for node_index in range(len(path.nodes)):
-                        if self._originNode == path.nodes[node_index]:
-                            return point(path_index, node_index)
-            return None
+            return self._find_indices_for_node(self._originNode)
 
     @origin.setter
     def origin(self, origin):
         self._origin = origin
         self._originNode = None
 
-    # FIXME: (jany) if the above is OK after review, do the same for the others
+    @property
+    def targetNode(self):
+        if self._targetNode is not None:
+            return self._targetNode
+        if self._target is not None:
+            return self._find_node_by_indices(self._target)
+
+    @targetNode.setter
+    def targetNode(self, node):
+        self._targetNode = node
+        self._target = None
+
+    @property
+    def target(self):
+        if self._target is not None:
+            return self._target
+        if self._targetNode is not None:
+            return self._find_indices_for_node(self._targetNode)
+
+    @target.setter
+    def target(self, target):
+        self._target = target
+        self._targetNode = None
+
+    @property
+    def otherNode1(self):
+        if self._otherNode1 is not None:
+            return self._otherNode1
+        if self._other1 is not None:
+            return self._find_node_by_indices(self._other1)
+
+    @otherNode1.setter
+    def otherNode1(self, node):
+        self._otherNode1 = node
+        self._other1 = None
+
+    @property
+    def other1(self):
+        if self._other1 is not None:
+            return self._other1
+        if self._otherNode1 is not None:
+            return self._find_indices_for_node(self._otherNode1)
+
+    @other1.setter
+    def other1(self, other1):
+        self._other1 = other1
+        self._otherNode1 = None
+
+    @property
+    def otherNode2(self):
+        if self._otherNode2 is not None:
+            return self._otherNode2
+        if self._other2 is not None:
+            return self._find_node_by_indices(self._other2)
+
+    @otherNode2.setter
+    def otherNode2(self, node):
+        self._otherNode2 = node
+        self._other2 = None
+
+    @property
+    def other2(self):
+        if self._other2 is not None:
+            return self._other2
+        if self._otherNode2 is not None:
+            return self._find_indices_for_node(self._otherNode2)
+
+    @other2.setter
+    def other2(self, other2):
+        self._other2 = other2
+        self._otherNode2 = None
 
 
 class GSFeature(GSBase):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1303,12 +1303,6 @@ class GSFontMaster(GSBase):
         self._name = name
         return name
 
-    @name.setter
-    def name(self, value):
-        # FIXME: (jany) TO REVIEW
-        self.customParameters['Master Name'] = value
-        self._name = value
-
     customParameters = property(
         lambda self: CustomParametersProxy(self),
         lambda self, value: CustomParametersProxy(self).setter(value))

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2723,3 +2723,13 @@ class GSFont(GSBase):
     @note.setter
     def note(self, value):
         self.customParameters["note"] = value
+
+    # FIXME: (jany) I don't understand why this is needed for
+    #   gridSubDivisions but it works without it for upm
+    @property
+    def gridSubDivisions(self):
+        return self.gridSubDivision
+
+    @gridSubDivisions.setter
+    def gridSubDivisions(self, value):
+        self.gridSubDivision = value

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2403,8 +2403,11 @@ class GSLayer(GSBase):
             return master
 
     def shouldWriteValueForKey(self, key):
-        if key in ("associatedMasterId", "name"):
+        if key == "associatedMasterId":
             return self.layerId != self.associatedMasterId
+        if key == "name":
+            return (self.name is not None and len(self.name) > 0 and
+                    self.layerId != self.associatedMasterId)
         if key in ("width"):
             return True
         return super(GSLayer, self).shouldWriteValueForKey(key)

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1159,38 +1159,6 @@ class GSGuideLine(GSBase):
         return self._parent
 
 
-class GSPartProperty(GSBase):
-    _classesForName = {
-         "name": unicode,
-         "bottomName": unicode,
-         "bottomValue": int,
-         "topName": unicode,
-         "topValue": int,
-    }
-    _keyOrder = (
-         "name",
-         "bottomName",
-         "bottomValue",
-         "topName",
-         "topValue",
-    )
-
-    def plistValue(self):
-        name = self.name
-        if needsQuotes(name):
-            name = '"%s"' % name
-        bottomName = self.bottomName
-        if needsQuotes(bottomName):
-            bottomName = '"%s"' % bottomName
-        topName = self.topName
-        if needsQuotes(topName):
-            topName = '"%s"' % topName
-        return ("{\nname = %s;\nbottomName = %s;\nbottomValue = %i;"
-                "\ntopName = %s;\ntopValue = %i;\n}" %
-                (name,  bottomName, self.bottomValue,
-                 topName, self.topValue))
-
-
 class GSFontMaster(GSBase):
     _classesForName = {
         "alignmentZones": GSAlignmentZone,
@@ -1834,10 +1802,23 @@ class GSComponent(GSBase):
 
 class GSSmartComponentAxis(GSBase):
     _classesForName = {
-        "name": str,
-        "topValue": float,
+        "name": unicode,
+        "bottomName": unicode,
         "bottomValue": float,
+        "topName": unicode,
+        "topValue": float,
     }
+    _keyOrder = (
+        "name",
+        "bottomName",
+        "bottomValue",
+        "topName",
+        "topValue",
+    )
+
+    def shouldWriteValueForKey(self, key):
+        # Always write the 5 values
+        return True
 
 
 class GSAnchor(GSBase):
@@ -2479,7 +2460,7 @@ class GSGlyph(GSBase):
         "leftKerningKey": unicode,
         "leftMetricsKey": unicode,
         "note": unicode,
-        "partsSettings": GSPartProperty,
+        "partsSettings": GSSmartComponentAxis,
         "production": str,
         "rightKerningGroup": unicode,
         "rightKerningKey": unicode,
@@ -2492,10 +2473,10 @@ class GSGlyph(GSBase):
         "userData": dict,
         "vertWidthMetricsKey": str,
         "widthMetricsKey": unicode,
-        "smartComponentAxes": GSSmartComponentAxis,
     }
     _wrapperKeysTranslate = {
-        "glyphname": "name"
+        "glyphname": "name",
+        "partsSettings": "smartComponentAxes",
     }
     _defaultsForName = {
         "category": None,
@@ -2538,7 +2519,6 @@ class GSGlyph(GSBase):
         "subCategory",
         "userData",
         "partsSettings",
-        "smartComponentAxes",
     )
     _userData = {}
 
@@ -2590,6 +2570,10 @@ class GSGlyph(GSBase):
     glyphname = property(
         lambda self: self.name,
         lambda self, value: setattr(self, "name", value))
+
+    smartComponentAxes = property(
+        lambda self: self.partsSettings,
+        lambda self, value: setattr(self, "partsSettings", value))
 
     @property
     def id(self):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2578,6 +2578,11 @@ class GSGlyph(GSBase):
     def __repr__(self):
         return '<GSGlyph "%s" with %s layers>' % (self.name, len(self.layers))
 
+    def shouldWriteValueForKey(self, key):
+        if key == "script" and self.script is not None:
+            return True
+        return super(GSGlyph, self).shouldWriteValueForKey(key)
+
     layers = property(lambda self: GlyphLayerProxy(self),
                       lambda self, value: GlyphLayerProxy(self).setter(value))
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1978,6 +1978,7 @@ class GSClass(GSFeature):
 class GSFeaturePrefix(GSFeature):
     pass
 
+
 class GSAnnotation(GSBase):
     _classesForName = {
         "angle": float,
@@ -2171,7 +2172,7 @@ class GSBackgroundImage(GSBase):
         "transform": transform(1, 0, 0, 1, 0, 0),
     }
 
-    def __init__(self, path = None):
+    def __init__(self, path=None):
         super(GSBackgroundImage, self).__init__()
         self.imagePath = path
         self._sX, self._sY, self._R = transformStructToScaleAndRotation(self.transform.value)
@@ -2185,6 +2186,7 @@ class GSBackgroundImage(GSBase):
         return self.imagePath
     @path.setter
     def path(self, value):
+        # FIXME: (jany) use posix pathnames here?
         if os.dirname(os.abspath(value)) == os.dirname(os.abspath(self.parent.parent.parent.filepath)):
             self.imagePath = os.path.basename(value)
         else:
@@ -2228,7 +2230,7 @@ class GSBackgroundImage(GSBase):
         self.transform = [affine[0], affine[1], affine[3], affine[4], affine[2], affine[5]]
 
 
-
+# FIXME: (jany) This class is not mentioned in the official docs?
 class GSBackgroundLayer(GSBase):
     _classesForName = {
         "anchors": GSAnchor,
@@ -2270,6 +2272,7 @@ class GSLayer(GSBase):
         "visible": bool,
         "width": float,
         "widthMetricsKey": unicode,
+        "smartComponentPoleMapping": dict,
     }
     _defaultsForName = {
         "weight": 600,
@@ -2299,7 +2302,9 @@ class GSLayer(GSBase):
         "vertWidth",
         "width",
     )
-    _userData = {}
+    # FIXME: (jany) with the line below, user data would be shared between all
+    #   instances of GSLayer!?
+    # _userData = {}
 
     def __init__(self):
         super(GSLayer, self).__init__()
@@ -2309,6 +2314,8 @@ class GSLayer(GSBase):
         self.guides = []
         self._paths = []
         self._selection = []
+        self.smartComponentPoleMapping = {}
+        self._userData = {}
 
     def __repr__(self):
         name = self.name

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -139,7 +139,7 @@ RTLTTB = 2
 
 class OnlyInGlyphsAppError(NotImplementedError):
     def __init__(self):
-        NotImplementedError.__init__(self, "This property/method is only available in the real UI-based version of Glyphs.app.") 
+        NotImplementedError.__init__(self, "This property/method is only available in the real UI-based version of Glyphs.app.")
 
 
 def hint_target(line=None):
@@ -1479,7 +1479,7 @@ class GSPath(GSBase):
             newSegment = segment()
             newSegment.parent = self
             newSegment.index = segmentCount
-            
+
             if nodeCount == 0:
                 newSegment.appendNode(self.nodes[-1])
             else:
@@ -1499,7 +1499,7 @@ class GSPath(GSBase):
             segmentCount += 1
 
         self._segments
-        return self._segments     
+        return self._segments
 
     @segments.setter
     def segments(self, value):
@@ -1595,7 +1595,7 @@ class GSPath(GSBase):
 
 
 class segment(list):
-    
+
     def appendNode(self, node):
         if not hasattr(self, 'nodes'): # instead of defining this in __init__(), because I hate super()
             self.nodes = []
@@ -1632,12 +1632,12 @@ class segment(list):
             return left, bottom, right, top
         else:
             raise ValueError
-                
+
     def bezierMinMax(self, x0, y0, x1, y1, x2, y2, x3, y3):
         tvalues = []
         xvalues = []
         yvalues = []
-    
+
         for i in range(2):
             if i == 0:
                 b = 6 * x0 - 12 * x1 + 6 * x2
@@ -1647,7 +1647,7 @@ class segment(list):
                 b = 6 * y0 - 12 * y1 + 6 * y2
                 a = -3 * y0 + 9 * y1 - 9 * y2 + 3 * y3
                 c = 3 * y1 - 3 * y0
-    
+
             if abs(a) < 1e-12:
                 if abs(b) < 1e-12:
                     continue
@@ -1655,7 +1655,7 @@ class segment(list):
                 if 0 < t and t < 1:
                     tvalues.append(t)
                 continue
-    
+
             b2ac = b * b - 4 * c * a
             if b2ac < 0:
                 continue
@@ -1666,7 +1666,7 @@ class segment(list):
             t2 = (-b - sqrtb2ac) / (2 * a)
             if 0 < t2 and t2 < 1:
                 tvalues.append(t2)
-    
+
         for j in range(len(tvalues) - 1, -1, -1):
             t = tvalues[j]
             mt = 1 - t
@@ -1680,12 +1680,12 @@ class segment(list):
                 yvalues[j] = newyValue
             else:
                 yvalues.append(newyValue)
-    
+
         xvalues.append(x0)
         xvalues.append(x3)
         yvalues.append(y0)
         yvalues.append(y3)
-    
+
         return min(xvalues), min(yvalues), max(xvalues), max(yvalues)
 
 
@@ -2645,16 +2645,6 @@ class GSFont(GSBase):
                 glyph._setupLayer(layer, layer.layerId)
 
     @property
-    def classes(self):
-        return self._classes
-
-    @classes.setter
-    def classes(self, value):
-        self._classes = value
-        for g in self._classes:
-            g._parent = self
-
-    @property
     def features(self):
         return self._features
 
@@ -2664,18 +2654,8 @@ class GSFont(GSBase):
         for g in self._features:
             g._parent = self
 
-    # @property
-    # def masters(self):
-    #     return self._masters
-
-    # @masters.setter
-    # def masters(self, value):
-    #     self._masters = value
-    #     for m in self._masters:
-    #         m.parent = self
-
     masters = property(lambda self: FontFontMasterProxy(self),
-                      lambda self, value: FontFontMasterProxy(self).setter(value))
+                       lambda self, value: FontFontMasterProxy(self).setter(value))
 
     def masterForId(self, key):
         for master in self._masters:

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1821,6 +1821,14 @@ class GSComponent(GSBase):
                 return rect(point(left, bottom), point(right - left, top - bottom))
 
 
+class GSSmartComponentAxis(GSBase):
+    _classesForName = {
+        "name": str,
+        "topValue": float,
+        "bottomValue": float,
+    }
+
+
 class GSAnchor(GSBase):
     _classesForName = {
         "name": unicode,
@@ -2452,6 +2460,7 @@ class GSGlyph(GSBase):
         "userData": dict,
         "vertWidthMetricsKey": str,
         "widthMetricsKey": unicode,
+        "smartComponentAxes": GSSmartComponentAxis,
     }
     _wrapperKeysTranslate = {
         "glyphname": "name"
@@ -2496,7 +2505,8 @@ class GSGlyph(GSBase):
         "category",
         "subCategory",
         "userData",
-        "partsSettings"
+        "partsSettings",
+        "smartComponentAxes",
     )
     _userData = {}
 
@@ -2507,6 +2517,7 @@ class GSGlyph(GSBase):
         self.parent = None
         self.export = True
         self.selected = False
+        self.smartComponentAxes = []
 
     def __repr__(self):
         return '<GSGlyph "%s" with %s layers>' % (self.name, len(self.layers))

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2013,6 +2013,13 @@ class GSAnnotation(GSBase):
     }
     _parent = None
 
+    # Annotation types
+    TEXT = "Text"
+    ARROW = "Arrow"
+    CIRCLE = "Circle"
+    PLUS = "Plus"
+    MINUS = "Minus"
+
     @property
     def parent(self):
         return self._parent

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1354,10 +1354,7 @@ class GSNode(GSBase):
 
     def __init__(self, position=(0, 0), nodetype=LINE,
                  smooth=False, name=None):
-        if isinstance(position, point):
-            self.position = position
-        else:
-            self.position = point(position[0], position[1])
+        self.position = point(position[0], position[1])
         self.type = nodetype
         self.smooth = smooth
         self.name = name

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2576,6 +2576,7 @@ class GSFont(GSBase):
         ".appVersion": "appVersion",
         "fontMaster": "_masters",
         "unitsPerEm": "upm",
+        "gridSubDivision": "gridSubDivisions"
     }
     _defaultsForName = {
         "classes": [],

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1016,6 +1016,10 @@ class GSCustomParameter(GSBase):
             (self.__class__.__name__, self.name, self._value)
 
     def plistValue(self):
+        # FIXME: (jany) This function looks like a re-implementation
+        #   of the writer, it may be simpler to cast the values in case
+        #   of known parameters and call
+        #   writer.writeDict({'name':name, 'value': value})
         name = self.name
         if needsQuotes(name):
             name = '"%s"' % name

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2535,6 +2535,12 @@ class GSGlyph(GSBase):
         lambda self: self.name,
         lambda self, value: setattr(self, "name", value))
 
+    @property
+    def id(self):
+        """An unique identifier for each glyph"""
+        # FIXME: (jany) what is it? it doesn't seem be stored in the file
+        return self.name
+
 
 class GSFont(GSBase):
     _classesForName = {

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1829,8 +1829,12 @@ class GSAnchor(GSBase):
         "position": point(0, 0),
     }
 
-    def __init__(self):
+    def __init__(self, name=None, position=None):
         super(GSAnchor, self).__init__()
+        if name is not None:
+            self.name = name
+        if position is not None:
+            self.position = position
 
     def __repr__(self):
         return '<%s "%s" x=%.1f y=%.1f>' % \

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1299,6 +1299,12 @@ class GSFontMaster(GSBase):
         self._name = name
         return name
 
+    @name.setter
+    def name(self, value):
+        # FIXME: (jany) TO REVIEW
+        self.customParameters['Master Name'] = value
+        self._name = value
+
     customParameters = property(
         lambda self: CustomParametersProxy(self),
         lambda self, value: CustomParametersProxy(self).setter(value))

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -44,7 +44,7 @@ __all__ = [
     "GSLayer",
     "GSAnchor",
     "GSComponent",
-#    "GSSmartComponentAxis",
+    "GSSmartComponentAxis",
     "GSPath",
     "GSNode",
     "GSGuideLine",
@@ -1351,26 +1351,12 @@ class GSNode(GSBase):
     _userData = {}
     _parent = None
 
-    def __init__(self, line=None, position=(0, 0), nodetype='line',
-                 smooth=False, name = None):
-        if line is not None:
-            m = re.match(self._rx, line).groups()
-            self.position = point(float(m[0]), float(m[1]))
-            self.type = m[2].lower()
-            self.smooth = bool(m[3])
-
-            # TODO: Use proper string parsing used in other classes
-            if '{\\nname' in line:
-                nameMatch = re.match(r'\{\\nname = "?(.+?)"?;\\n\}', m[4]).groups()
-                self.name = nameMatch[0]
-            else:
-                self.name = None
-
-        else:
-            self.position = point(position[0], position[1])
-            self.type = nodetype
-            self.smooth = smooth
-            self.name = name
+    def __init__(self, position=(0, 0), nodetype=LINE,
+                 smooth=False, name=None):
+        self.position = point(position[0], position[1])
+        self.type = nodetype
+        self.smooth = smooth
+        self.name = name
         self._parent = None
 
     def __repr__(self):
@@ -1398,6 +1384,21 @@ class GSNode(GSBase):
         return '"%s %s %s"' % \
             (floatToString(self.position[0]), floatToString(self.position[1]),
              content)
+
+    def read(self, line):
+        m = re.match(self._rx, line).groups()
+        self.position = point(float(m[0]), float(m[1]))
+        self.type = m[2].lower()
+        self.smooth = bool(m[3])
+
+        # TODO: Use proper string parsing used in other classes
+        if '{\\nname' in line:
+            nameMatch = re.match(r'\{\\nname = "?(.+?)"?;\\n\}', m[4]).groups()
+            self.name = nameMatch[0]
+        else:
+            self.name = None
+
+        return self
 
     @property
     def index(self):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -26,7 +26,7 @@ from glyphsLib.types import (
     encode_dict_as_string_for_gsnode, decode_dict_as_string_from_gsnode
 )
 from glyphsLib.parser import Parser
-from glyphsLib.writer import GlyphsWriter
+from glyphsLib.writer import Writer
 from collections import OrderedDict
 from fontTools.misc.py23 import unicode, basestring, StringIO, unichr
 from glyphsLib.affine import Affine
@@ -1067,12 +1067,12 @@ class GSCustomParameter(GSBase):
                     v = str(v)
                 elif isinstance(v, dict):
                     string = StringIO()
-                    writer = GlyphsWriter(fp=string)
+                    writer = Writer(fp=string)
                     writer.writeDict(v)
                     v = string.getvalue()
                 elif isinstance(v, list):
                     string = StringIO()
-                    writer = GlyphsWriter(fp=string)
+                    writer = Writer(fp=string)
                     writer.writeArray(v)
                     v = string.getvalue()
                 else:
@@ -1373,7 +1373,7 @@ class GSNode(GSBase):
         if self._userData is not None and len(self._userData) > 0:
             # FIXME: (jany) must provide a simpler way to write a string
             string = StringIO()
-            writer = GlyphsWriter(fp=string)
+            writer = Writer(fp=string)
             writer.writeDict(self._userData)
             content += ' '
             content += encode_dict_as_string_for_gsnode(string.getvalue())
@@ -2718,9 +2718,9 @@ class GSFont(GSBase):
 
     def save(self, path=None):
         if path:
-            writer = GlyphsWriter(path)
+            writer = Writer(path)
         elif self.filepath:
-            writer = GlyphsWriter(self.filepath)
+            writer = Writer(self.filepath)
         else:
             raise ValueError
         writer.write(self)

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -254,6 +254,9 @@ class GSBase(object):
         value = getattr(self, getKey)
         klass = self._classesForName[key]
         default = self._defaultsForName.get(key, None)
+        if (isinstance(value, (list, glyphsLib.classes.Proxy,
+                               str, unicode)) and len(value) == 0):
+            return False
         if default is not None:
             return default != value
         if klass in (int, float, bool) and value == 0:
@@ -1851,8 +1854,9 @@ class GSSmartComponentAxis(GSBase):
     )
 
     def shouldWriteValueForKey(self, key):
-        # Always write the 5 values
-        return True
+        if key in ("bottomValue", "topValue"):
+            return True
+        return super(GSSmartComponentAxis, self).shouldWriteValueForKey(key)
 
 
 class GSAnchor(GSBase):
@@ -2310,9 +2314,6 @@ class GSBackgroundLayer(GSBase):
     }
 
     def shouldWriteValueForKey(self, key):
-        if key == "backgroundImage":
-            return hasattr(self, key)
-            return len(value) > 0
         return super(GSBackgroundLayer, self).shouldWriteValueForKey(key)
 
 
@@ -2407,9 +2408,6 @@ class GSLayer(GSBase):
             return self.layerId != self.associatedMasterId
         if key in ("width"):
             return True
-        if key == "backgroundImage":
-            return hasattr(self, key)
-            return len(value) > 0
         return super(GSLayer, self).shouldWriteValueForKey(key)
 
     @property

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1214,6 +1214,9 @@ class GSFontMaster(GSBase):
     _defaultsForName = {
         "weightValue": 100.0,
         "widthValue": 100.0,
+        "xHeight": 500,
+        "capHeight": 700,
+        "ascender": 800,
     }
     _wrapperKeysTranslate = {
         "guideLines": "guides",
@@ -1258,8 +1261,6 @@ class GSFontMaster(GSBase):
         self.italicAngle = 0.0
         self.customValue = 0.0
         self._userData = None
-        self.xHeight = None
-        self.capHeight = None
 
     def __repr__(self):
         return '<GSFontMaster "%s" width %s weight %s>' % \
@@ -1270,8 +1271,8 @@ class GSFontMaster(GSBase):
             if getattr(self, key) == "Regular":
                 return False
             return True
-        if key in ("xHeight", "capHeight") and getattr(self, key) is not None:
-            # Write those values even when == 0
+        if key in ("xHeight", "capHeight", "ascender"):
+            # Always write those values
             return True
         return super(GSFontMaster, self).shouldWriteValueForKey(key)
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -206,7 +206,6 @@ class GSApplication(object):
 Glyphs = GSApplication()
 
 
-
 class GSBase(object):
     _classesForName = {}
     _defaultsForName = {}
@@ -2577,8 +2576,8 @@ class GSGlyph(GSBase):
         return '<GSGlyph "%s" with %s layers>' % (self.name, len(self.layers))
 
     def shouldWriteValueForKey(self, key):
-        if key == "script" and self.script is not None:
-            return True
+        if key in ("script", "category", "subCategory"):
+            return getattr(self, key) is not None
         return super(GSGlyph, self).shouldWriteValueForKey(key)
 
     layers = property(lambda self: GlyphLayerProxy(self),

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1680,11 +1680,12 @@ class GSComponent(GSBase):
         "name": unicode,
         "piece": dict,
         "transform": transform,
-        "smartComponentValues": dict,
+    }
+    _wrapperKeysTranslate = {
+        "piece": "smartComponentValues",
     }
     _defaultsForName = {
         "transform": transform(1, 0, 0, 1, 0, 0),
-        "smartComponentValues": None,
     }
     _parent = None
 
@@ -1798,6 +1799,10 @@ class GSComponent(GSBase):
 
             if left is not None and bottom is not None and right is not None and top is not None:
                 return rect(point(left, bottom), point(right - left, top - bottom))
+
+    smartComponentValues = property(
+        lambda self: self.piece,
+        lambda self, value: setattr(self, "piece", value))
 
 
 class GSSmartComponentAxis(GSBase):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1701,9 +1701,11 @@ class GSComponent(GSBase):
         "name": unicode,
         "piece": dict,
         "transform": transform,
+        "smartComponentValues": dict,
     }
     _defaultsForName = {
         "transform": transform(1, 0, 0, 1, 0, 0),
+        "smartComponentValues": None,
     }
     _parent = None
 

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -2683,6 +2683,7 @@ class GSFont(GSBase):
         self._classes = []
         self.filepath = None
         self._userData = None
+        self.keyboardIncrement = None
 
         if path:
             assert isinstance(path, (str, unicode)), \

--- a/Lib/glyphsLib/interpolation.py
+++ b/Lib/glyphsLib/interpolation.py
@@ -21,9 +21,9 @@ import logging
 import os
 import xml.etree.ElementTree as etree
 
-from glyphsLib.builder import (
-    set_custom_params, GLYPHS_PREFIX, build_stylemap_names
-)
+from glyphsLib.builder.ufo import set_custom_params, build_stylemap_names
+from glyphsLib.builder.constants import GLYPHS_PREFIX
+
 from glyphsLib.util import build_ufo_path, write_ufo, clean_ufo, clear_data
 
 __all__ = [

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -61,6 +61,10 @@ class Parser:
         return i
 
     def _guess_dict_type(self, parsed, value):
+        if value in ('infinity', 'inf', 'nan'):
+            # Those values would be accepted by `float()`
+            # But `infinity` is a glyph name
+            return unicode
         if parsed[-1] != '"':
             try:
                 float_val = float(value)

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -98,7 +98,6 @@ class Parser:
                 value = reader.read(value)
                 return value, i
 
-
             if self.dict_type is None:  # for custom parameters
                 self.dict_type = self._guess_dict_type(parsed, value)
 
@@ -181,9 +180,9 @@ class Parser:
                                text, i)
                 parsed = m.group(0)
                 i += len(parsed)
+            self.dict_type = old_dict_type
 
         parsed = end_match.group(0)
-        self.dict_type = old_dict_type
         i += len(parsed)
         return res, i
 

--- a/Lib/glyphsLib/roundtrip.py
+++ b/Lib/glyphsLib/roundtrip.py
@@ -47,6 +47,5 @@ def to_glyphs_master(ufo):
     Extract from the given UFO the data that goes into a GSFontMaster.
     """
     master = classes.GSFontMaster()
-    #import pdb; pdb.set_trace()
     master.id = ufo.lib[builder.GLYPHS_PREFIX + 'fontMasterID']
     return master

--- a/Lib/glyphsLib/roundtrip.py
+++ b/Lib/glyphsLib/roundtrip.py
@@ -1,0 +1,52 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from glyphsLib import classes
+from glyphsLib import builder
+
+# def designspace_from_ufos(ufos):
+#     pass
+
+# def to_glyphs(designspace):
+#     # For later
+#     """Transform a MutatorMath designspace into a GSFont.
+
+#     This should be the inverse function of `to_designspace` from `builder.py`,
+#     so we should have to_glyphs(to_designspace(font)) == font
+#     """
+#     pass
+
+
+def to_glyphs(ufos):
+    """
+    Take a list of UFOs and combine them into a single .glyphs file.
+
+    This should be the inverse function of `to_ufos` from `builder.py`,
+    so we should have to_glyphs(to_ufos(font)) == font
+    """
+    font = classes.GSFont()
+    for ufo in ufos:
+        master = to_glyphs_master(ufo)
+        font.masters.insert(len(font.masters), master)
+    return font
+
+
+def to_glyphs_master(ufo):
+    """
+    Extract from the given UFO the data that goes into a GSFontMaster.
+    """
+    master = classes.GSFontMaster()
+    #import pdb; pdb.set_trace()
+    master.id = ufo.lib[builder.GLYPHS_PREFIX + 'fontMasterID']
+    return master

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -343,6 +343,8 @@ NSPropertyListNameSet = (
 
 
 def needsQuotes(string):
+    if len(string) == 0:
+        return True
     needsQuotes = False
     if not isinstance(string, (str, unicode)):
         return False

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -370,6 +370,14 @@ def encode_dict_as_string_for_gsnode(value):
     return value.replace("\n", "\\n")
 
 
+# FIXME: (jany) This is not a correct reverse function, if
+#   the input string contains "\\n"
+def decode_dict_as_string_from_gsnode(value):
+    """Inverse of encode_dict_as_string_for_gsnode"""
+    value = value.replace('\\"', '"')
+    return value.replace("\\n", "\n")
+
+
 def feature_syntax_encode(value):
     if isinstance(value, (str, unicode)) and needsQuotes(value):
 

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -298,15 +298,15 @@ def floatToString(Float, precision=3):
         ActualPrecition = actualPrecition(Float)
         precision = min(precision, ActualPrecition)
         fractional = math.modf(math.fabs(Float))[0]
-        if precision >= 5 and fractional >= 0.00001 and fractional <= 0.99999:
+        if precision >= 5 and fractional >= 0.000005 and fractional <= 0.999995:
             return "%.5f" % Float
-        elif precision >= 4 and fractional >= 0.0001 and fractional <= 0.9999:
+        elif precision >= 4 and fractional >= 0.00005 and fractional <= 0.99995:
             return "%.4f" % Float
-        elif precision >= 3 and fractional >= 0.001 and fractional <= 0.999:
+        elif precision >= 3 and fractional >= 0.0005 and fractional <= 0.9995:
             return "%.3f" % Float
-        elif precision >= 2 and fractional >= 0.01 and fractional <= 0.99:
+        elif precision >= 2 and fractional >= 0.005 and fractional <= 0.995:
             return "%.2f" % Float
-        elif precision >= 1 and fractional >= 0.1 and fractional <= 0.9:
+        elif precision >= 1 and fractional >= 0.05 and fractional <= 0.95:
             return "%.1f" % Float
         else:
             return "%.0f" % Float

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -361,6 +361,15 @@ def needsQuotes(string):
     return needsQuotes
 
 
+# FIXME: (jany) why is `feature_syntax_encode` different?
+def encode_dict_as_string_for_gsnode(value):
+    """Takes the PLIST string of a dict, and returns the same string
+    encoded such that it can be included in the string representation
+    of a GSNode."""
+    value = value.replace('"', '\\"')
+    return value.replace("\n", "\\n")
+
+
 def feature_syntax_encode(value):
     if isinstance(value, (str, unicode)) and needsQuotes(value):
 

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -52,9 +52,9 @@ class point(object):
     """Read/write a vector in curly braces."""
     dimension = 2
     default = [None, None]
-    regex = re.compile('{%s}' % ', '.join(['([-.e\d]+)'] * dimension))
+    regex = re.compile('{%s}' % ', '.join(['([-.e\\d]+)'] * dimension))
 
-    def __init__(self, value = None, value2 = None, rect = None):
+    def __init__(self, value=None, value2=None, rect=None):
         if value is not None and value2 is not None:
             self.value = [value, value2]
         elif value is not None and value2 is None:
@@ -72,7 +72,6 @@ class point(object):
                 len(self.value) == self.dimension)
         if self.value is not self.default:
             return '"{%s}"' % (', '.join(floatToString(v, 3) for v in self.value))
-    
 
     def __getitem__(self, key):
         if type(key) is int and key < self.dimension:

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -79,11 +79,6 @@ class GlyphsWriter(object):
                 continue
             if value is None:
                 continue
-            if (key != "code" and key != "script" and  # FIXME: (jany) ugly
-                    isinstance(value, (list, glyphsLib.classes.Proxy,
-                                       str, unicode)) and
-                    len(value) == 0):
-                continue
             if (hasattr(dictValue, "shouldWriteValueForKey") and
                     not dictValue.shouldWriteValueForKey(key)):
                 continue

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -27,13 +27,13 @@ from fontTools.misc.py23 import unicode, open
 '''
     Usage
 
-    writer = GlyphsWriter('Path/to/File.glyphs')
+    writer = Writer('Path/to/File.glyphs')
     writer.write(font)
 
 '''
 
 
-class GlyphsWriter(object):
+class Writer(object):
 
     def __init__(self, filePath=None, fp=None):
 

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -79,8 +79,9 @@ class GlyphsWriter(object):
                 continue
             if value is None:
                 continue
-            if (isinstance(value,
-                           (list, glyphsLib.classes.Proxy, str, unicode)) and
+            if (key != "code" and  # FIXME: (jany) ugly
+                    isinstance(value, (list, glyphsLib.classes.Proxy,
+                                       str, unicode)) and
                     len(value) == 0):
                 continue
             if (hasattr(dictValue, "shouldWriteValueForKey") and
@@ -95,6 +96,8 @@ class GlyphsWriter(object):
         self.file.write("(\n")
         idx = 0
         length = len(arrayValue)
+        if hasattr(arrayValue, "plistArray"):
+            arrayValue = arrayValue.plistArray()
         for value in arrayValue:
             self.writeValue(value)
             if idx < length - 1:

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -79,7 +79,7 @@ class GlyphsWriter(object):
                 continue
             if value is None:
                 continue
-            if (key != "code" and  # FIXME: (jany) ugly
+            if (key != "code" and key != "script" and  # FIXME: (jany) ugly
                     isinstance(value, (list, glyphsLib.classes.Proxy,
                                        str, unicode)) and
                     len(value) == 0):

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -37,18 +37,21 @@ class GlyphsWriter(object):
 
     def __init__(self, filePath=None, fp=None):
 
+        self.close = False
         if fp is not None:
             self.file = fp
         elif filePath is None:
             self.file = sys.stdout
         else:
             self.file = open(filePath, "w")
+            self.close = True
 
     def write(self, baseObject):
 
         self.writeDict(baseObject)
         self.file.write("\n")
-        self.file.close()
+        if self.close:
+            self.file.close()
 
     def writeDict(self, dictValue):
         self.file.write("{\n")

--- a/noto_pytest.ini
+++ b/noto_pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+minversion = 2.8
+python_files =
+    tests/run_roundtrip_on_noto.py
+python_classes =
+	*Test
+addopts =
+	-v
+	-r a

--- a/noto_pytest.ini
+++ b/noto_pytest.ini
@@ -4,6 +4,7 @@ python_files =
     tests/run_roundtrip_on_noto.py
 python_classes =
 	*Test
+python_functions =
 addopts =
 	-v
 	-r a

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -36,9 +36,11 @@ from glyphsLib.classes import GSFont, GSFontMaster, GSInstance, \
     GSComponent, GSAlignmentZone, GSGuideLine
 from glyphsLib.types import point
 
-from glyphsLib.builder import build_style_name, set_custom_params,\
-    to_ufos, GLYPHS_PREFIX, PUBLIC_PREFIX, GLYPHLIB_PREFIX, draw_paths, \
-    set_default_params, parse_glyphs_filter, build_stylemap_names
+from glyphsLib.builder.ufo import build_style_name, set_custom_params, \
+    to_ufos, draw_paths, set_default_params, parse_glyphs_filter, \
+    build_stylemap_names
+from glyphsLib.builder.constants import GLYPHS_PREFIX, PUBLIC_PREFIX, \
+    GLYPHLIB_PREFIX
 
 from classes_test import generate_minimal_font, generate_instance_from_dict, \
     add_glyph, add_anchor, add_component
@@ -310,7 +312,7 @@ class SetCustomParamsTest(unittest.TestCase):
         set_custom_params(self.ufo, parsed=[('underlineThickness', 0)])
         self.assertEqual(self.ufo.info.postscriptUnderlineThickness, 0)
 
-    @patch('glyphsLib.builder.parse_glyphs_filter')
+    @patch('glyphsLib.builder.ufo.parse_glyphs_filter')
     def test_parse_glyphs_filter(self, mock_parse_glyphs_filter):
         filter1 = ('Filter', 'Transformations;OffsetX:40;OffsetY:60;include:uni0334,uni0335')
         filter2 = ('Filter', 'Transformations;OffsetX:10;OffsetY:-10;exclude:uni0334,uni0335')

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -876,7 +876,7 @@ class ToUfosTest(unittest.TestCase):
 
     def test_lib_custom(self):
         font = generate_minimal_font()
-        font.masters[0].custom = 'FooBar'
+        font.masters[0].customName = 'FooBar'
         ufo = to_ufos(font)[0]
         self.assertEqual(ufo.lib[GLYPHS_PREFIX + 'custom'], 'FooBar')
 
@@ -893,7 +893,7 @@ class ToUfosTest(unittest.TestCase):
             guide = GSGuideLine()
             guide.position = pt
             guide.angle = guide_data['angle']
-            layer.guideLines.append(guide)
+            layer.guides.append(guide)
         glyph.layers.append(layer)
         ufo = to_ufos(font)[0]
         self.assertEqual(ufo['a'].guidelines, expected)

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -411,6 +411,10 @@ class GSFontFromFileTest(GSObjectsTestCase):
         self.assertEqual(amount, len(list(font.customParameters)))
         del font.customParameters['trademark']
 
+    def test_font_master_is_name_not_writable(self):
+        """Match the Glyphs python API"""
+        with self.assertRaises(AttributeError):
+            self.font.masters[0].name = "Test"
 
     # TODO: selection, selectedLayers, currentText, tabs, currentTab
 

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -1341,6 +1341,9 @@ class GSNodeFromFileTest(GSObjectsTestCase):
     def test_name(self):
         self.assertEqual(self.node.name, 'Hello')
 
+    def test_userData(self):
+        self.assertEqual(1, self.node.userData["rememberToMakeCoffee"])
+
     def test_makeNodeFirst(self):
         oldAmount = len(self.path.nodes)
         oldSecondNode = self.path.nodes[3]

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -53,7 +53,7 @@ def generate_minimal_font():
     master.xHeight = 0
     font.masters.append(master)
 
-    font.unitsPerEm = 1000
+    font.upm = 1000
     font.versionMajor = 1
     font.versionMinor = 0
 
@@ -501,18 +501,18 @@ class GSFontMasterFromFileTest(GSObjectsTestCase):
         # TODO otherBlues
         # self.assertIsInstance(master.otherBlues, list)
 
-        # guideLines
-        self.assertIsInstance(master.guideLines, list)
-        master.guideLines = []
-        self.assertEqual(len(master.guideLines), 0)
+        # guides
+        self.assertIsInstance(master.guides, list)
+        master.guides = []
+        self.assertEqual(len(master.guides), 0)
         newGuide = GSGuideLine()
         newGuide.position = point("{100, 100}")
         newGuide.angle = -10.0
-        master.guideLines.append(newGuide)
-        self.assertIsNotNone(master.guideLines[0].__repr__())
-        self.assertEqual(len(master.guideLines), 1)
-        del master.guideLines[0]
-        self.assertEqual(len(master.guideLines), 0)
+        master.guides.append(newGuide)
+        self.assertIsNotNone(master.guides[0].__repr__())
+        self.assertEqual(len(master.guides), 1)
+        del master.guides[0]
+        self.assertEqual(len(master.guides), 0)
 
         # guides
         self.assertIsInstance(master.guides, list)
@@ -916,24 +916,23 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         layer.components.remove(component)
         self.assertEqual(len(layer.components), amount)
 
-    # TODO also layer.guides
-    def test_guideLines(self):
+    def test_guides(self):
         layer = self.layer
-        self.assertIsInstance(layer.guideLines, LayerGuideLinesProxy)
-        for guide in layer.guideLines:
+        self.assertIsInstance(layer.guides, LayerGuideLinesProxy)
+        for guide in layer.guides:
             self.assertEqual(guide.parent, layer)
-        layer.guideLines = []
-        self.assertEqual(len(layer.guideLines), 0)
+        layer.guides = []
+        self.assertEqual(len(layer.guides), 0)
         newGuide = GSGuideLine()
         newGuide.position = point("{100, 100}")
         newGuide.angle = -10.0
-        amount = len(layer.guideLines)
-        layer.guideLines.append(newGuide)
+        amount = len(layer.guides)
+        layer.guides.append(newGuide)
         self.assertEqual(newGuide.parent, layer)
-        self.assertIsNotNone(layer.guideLines[0].__repr__())
-        self.assertEqual(len(layer.guideLines), amount + 1)
-        del layer.guideLines[0]
-        self.assertEqual(len(layer.guideLines), amount)
+        self.assertIsNotNone(layer.guides[0].__repr__())
+        self.assertEqual(len(layer.guides), amount + 1)
+        del layer.guides[0]
+        self.assertEqual(len(layer.guides), amount)
 
     def test_annotations(self):
         layer = self.layer

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -342,7 +342,7 @@ class GSFontFromFileTest(GSObjectsTestCase):
 
     def test_ints(self):
         attributes = [
-            "versionMajor", "versionMajor", "upm", "grid", "gridSubDivision",
+            "versionMajor", "versionMajor", "upm", "grid", "gridSubDivisions",
         ]
         font = self.font
         for attr in attributes:

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -27,7 +27,7 @@ from fontTools.misc.py23 import unicode
 from glyphsLib.classes import (
     GSFont, GSFontMaster, GSInstance, GSCustomParameter, GSGlyph, GSLayer,
     GSAnchor, GSComponent, GSAlignmentZone, GSClass, GSFeature, GSAnnotation,
-    GSFeaturePrefix, GSGuideLine, GSHint, GSNode,
+    GSFeaturePrefix, GSGuideLine, GSHint, GSNode, GSSmartComponentAxis,
     LayerComponentsProxy, LayerGuideLinesProxy,
     STEM
 )
@@ -831,8 +831,19 @@ class GSGlyphFromFileTest(GSObjectsTestCase):
         self.assertIsNone(glyph.userData.get("unitTestValue"))
         self.assertEqual(len(glyph.userData), amount)
 
-    # TODO
-    # glyph.smartComponentAxes
+    def test_smart_component_axes(self):
+        shoulder = self.font.glyphs['_part.shoulder']
+        axes = shoulder.smartComponentAxes
+        self.assertIsNotNone(axes)
+        crotch_depth, shoulder_width = axes
+        self.assertIsInstance(crotch_depth, GSSmartComponentAxis)
+        self.assertEqual("crotchDepth", crotch_depth.name)
+        self.assertEqual(0, crotch_depth.topValue)
+        self.assertEqual(-100, crotch_depth.bottomValue)
+        self.assertIsInstance(shoulder_width, GSSmartComponentAxis)
+        self.assertEqual("shoulderWidth", shoulder_width.name)
+        self.assertEqual(100, shoulder_width.topValue)
+        self.assertEqual(0, shoulder_width.bottomValue)
 
     # TODO
     # lastChange

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -1217,23 +1217,23 @@ class GSPathFromFileTest(GSObjectsTestCase):
         self.assertEqual(len(path.nodes), 44)
         for node in path.nodes:
             self.assertEqual(node.parent, path)
-        # amount = len(path.nodes)
-        # newNode = GSNode(point("{100, 100}"))
-        # path.nodes.append(newNode)
-        # self.assertEqual(newNode, path.nodes[-1])
-        # del path.nodes[-1]
-        # newNode = GSNode(point("{20, 20}"))
-        # path.nodes.insert(0, newNode)
-        # self.assertEqual(newNode, path.nodes[0])
-        # path.nodes.remove(path.nodes[0])
-        # newNode1 = GSNode(point("{10, 10}"))
-        # newNode2 = GSNode(point("{20, 20}"))
-        # path.nodes.extend([newNode1, newNode2])
-        # self.assertEqual(newNode1, path.nodes[-2])
-        # self.assertEqual(newNode2, path.nodes[-1])
-        # del path.nodes[-2]
-        # del path.nodes[-1]
-        # self.assertEqual(amount, len(path.nodes))
+        amount = len(path.nodes)
+        newNode = GSNode(point("{100, 100}"))
+        path.nodes.append(newNode)
+        self.assertEqual(newNode, path.nodes[-1])
+        del path.nodes[-1]
+        newNode = GSNode(point("{20, 20}"))
+        path.nodes.insert(0, newNode)
+        self.assertEqual(newNode, path.nodes[0])
+        path.nodes.remove(path.nodes[0])
+        newNode1 = GSNode(point("{10, 10}"))
+        newNode2 = GSNode(point("{20, 20}"))
+        path.nodes.extend([newNode1, newNode2])
+        self.assertEqual(newNode1, path.nodes[-2])
+        self.assertEqual(newNode2, path.nodes[-1])
+        del path.nodes[-2]
+        del path.nodes[-1]
+        self.assertEqual(amount, len(path.nodes))
 
     # TODO: GSPath.closed
 

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -29,6 +29,7 @@ from glyphsLib.classes import (
     GSAnchor, GSComponent, GSAlignmentZone, GSClass, GSFeature, GSAnnotation,
     GSFeaturePrefix, GSGuideLine, GSHint, GSNode,
     LayerComponentsProxy, LayerGuideLinesProxy,
+    STEM
 )
 from glyphsLib.types import point, transform, rect, size
 
@@ -956,7 +957,7 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         newHint = copy.copy(newHint)
         newHint.originNode = layer.paths[0].nodes[0]
         newHint.targetNode = layer.paths[0].nodes[1]
-        newHint.type = GSHint.STEM
+        newHint.type = STEM
         layer.hints.append(newHint)
         self.assertIsNotNone(layer.hints[0].__repr__())
         self.assertEqual(len(layer.hints), 1)
@@ -965,11 +966,11 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         newHint1 = GSHint()
         newHint1.originNode = layer.paths[0].nodes[0]
         newHint1.targetNode = layer.paths[0].nodes[1]
-        newHint1.type = GSHint.STEM
+        newHint1.type = STEM
         newHint2 = GSHint()
         newHint2.originNode = layer.paths[0].nodes[0]
         newHint2.targetNode = layer.paths[0].nodes[1]
-        newHint2.type = GSHint.STEM
+        newHint2.type = STEM
         layer.hints.extend([newHint1, newHint2])
         newHint = GSHint()
         newHint.originNode = layer.paths[0].nodes[0]

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -1181,8 +1181,18 @@ class GSComponentFromFileTest(GSObjectsTestCase):
     def test_anchor(self):
         self.assertString(self.component.anchor)
 
+    def test_smartComponentValues(self):
+        glyph = self.font.glyphs["h"]
+        stem, shoulder = glyph.layers[0].components
+        self.assertEqual(100, stem.smartComponentValues["height"])
+        self.assertEqual(-80.20097, shoulder.smartComponentValues["crotchDepth"])
 
-    # TODO smartComponentValues
+        # FIXME: (jany) which one?
+        # self.assertEqual(0, shoulder.smartComponentValues["shoulderWidth"])
+        self.assertNotIn("shoulderWidth", shoulder.smartComponentValues)
+
+        self.assertNotIn("somethingElse", shoulder.smartComponentValues)
+
     # bezierPath?
     # componentLayer()
 

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -970,6 +970,21 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         layer.annotations.remove(layer.annotations[-1])
         self.assertEqual(len(layer.annotations), 0)
 
+    def test_hints_from_file(self):
+        glyph = self.font.glyphs["A"]
+        layer = glyph.layers[1]
+        self.assertEqual(2, len(layer.hints))
+        first, second = layer.hints
+        self.assertIsInstance(first, GSHint)
+        self.assertTrue(first.horizontal)
+        self.assertIsInstance(first.originNode, GSNode)
+        first_origin_node = layer.paths[1].nodes[1]
+        self.assertEqual(first_origin_node, first.originNode)
+
+        self.assertIsInstance(second, GSHint)
+        second_target_node = layer.paths[0].nodes[4]
+        self.assertEqual(second_target_node, second.targetNode)
+
     def test_hints(self):
         layer = self.layer
         # layer.hints = []

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -373,6 +373,16 @@ class GSFontFromFileTest(GSObjectsTestCase):
 
     def test_userData(self):
         font = self.font
+        self.assertEqual(font.userData["AsteriskParameters"], {
+            "253E7231-480D-4F8E-8754-50FC8575C08E": [
+                "754",
+                "30",
+                7,
+                51,
+                "80",
+                "50",
+            ],
+        })
         # self.assertIsInstance(font.userData, dict)
         # TODO
         self.assertIsNone(font.userData["TestData"])

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -1187,8 +1187,6 @@ class GSComponentFromFileTest(GSObjectsTestCase):
         self.assertEqual(100, stem.smartComponentValues["height"])
         self.assertEqual(-80.20097, shoulder.smartComponentValues["crotchDepth"])
 
-        # FIXME: (jany) which one?
-        # self.assertEqual(0, shoulder.smartComponentValues["shoulderWidth"])
         self.assertNotIn("shoulderWidth", shoulder.smartComponentValues)
 
         self.assertNotIn("somethingElse", shoulder.smartComponentValues)

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -752,6 +752,10 @@ class GSGlyphFromFileTest(GSObjectsTestCase):
         glyph = self.font.glyphs["adieresis"]
         self.assertEqual(glyph.string, "ä")
 
+    def test_id(self):
+        # TODO
+        pass
+
     # TODO
     # category
     # storeCategory

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -29,7 +29,7 @@ from glyphsLib.classes import (
     GSAnchor, GSComponent, GSAlignmentZone, GSClass, GSFeature, GSAnnotation,
     GSFeaturePrefix, GSGuideLine, GSHint, GSNode, GSSmartComponentAxis,
     LayerComponentsProxy, LayerGuideLinesProxy,
-    STEM
+    STEM, TEXT, ARROW, CIRCLE, PLUS, MINUS
 )
 from glyphsLib.types import point, transform, rect, size
 
@@ -378,7 +378,7 @@ class GSFontFromFileTest(GSObjectsTestCase):
         self.assertIsNone(font.userData["TestData"])
         font.userData["TestData"] = 42
         self.assertEqual(font.userData["TestData"], 42)
-        self.assertTrue(42 in font.userData)
+        self.assertTrue("TestData" in font.userData)
         del(font.userData["TestData"])
         self.assertIsNone(font.userData["TestData"])
 
@@ -930,7 +930,7 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         # self.assertEqual(layer.annotations, [])
         self.assertEqual(len(layer.annotations), 0)
         newAnnotation = GSAnnotation()
-        newAnnotation.type = 1  # TEXT
+        newAnnotation.type = TEXT
         newAnnotation.text = 'This curve is ugly!'
         layer.annotations.append(newAnnotation)
         # TODO position.x, position.y
@@ -939,11 +939,11 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         del layer.annotations[0]
         self.assertEqual(len(layer.annotations), 0)
         newAnnotation1 = GSAnnotation()
-        newAnnotation1.type = 2  # ARROW
+        newAnnotation1.type = ARROW
         newAnnotation2 = GSAnnotation()
-        newAnnotation2.type = 3  # CIRCLE
+        newAnnotation2.type = CIRCLE
         newAnnotation3 = GSAnnotation()
-        newAnnotation3.type = 4  # PLUS
+        newAnnotation3.type = PLUS
         layer.annotations.extend([newAnnotation1, newAnnotation2,
                                   newAnnotation3])
         self.assertEqual(layer.annotations[-3], newAnnotation1)
@@ -951,7 +951,7 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         self.assertEqual(layer.annotations[-1], newAnnotation3)
         newAnnotation = GSAnnotation()
         newAnnotation = copy.copy(newAnnotation)
-        newAnnotation.type = 5  # MINUS
+        newAnnotation.type = MINUS
         layer.annotations.insert(0, newAnnotation)
         self.assertEqual(layer.annotations[0], newAnnotation)
         layer.annotations.remove(layer.annotations[0])
@@ -1061,7 +1061,30 @@ class GSLayerFromFileTest(GSObjectsTestCase):
         # self.assertDict(layer.userData)
         layer.userData["Hallo"] = "Welt"
         self.assertEqual(layer.userData["Hallo"], "Welt")
-        self.assertTrue("Welt" in layer.userData)
+        self.assertTrue("Hallo" in layer.userData)
+
+    def test_smartComponentPoleMapping(self):
+        # http://docu.glyphsapp.com/#smartComponentPoleMapping
+        # Read some data from the file
+        shoulder = self.font.glyphs["_part.shoulder"]
+        for layer in shoulder.layers:
+            if layer.name == "NarrowShoulder":
+                mapping = layer.smartComponentPoleMapping
+                self.assertIsNotNone(mapping)
+                # crotchDepth is at the top pole
+                self.assertEqual(2, mapping["crotchDepth"])
+                # shoulderWidth is at the bottom pole
+                self.assertEqual(1, mapping["shoulderWidth"])
+
+        # Exercise the getter/setter
+        layer = self.layer
+        self.assertDict(layer.smartComponentPoleMapping)
+        self.assertFalse("crotchDepth" in layer.smartComponentPoleMapping)
+        layer.smartComponentPoleMapping["crotchDepth"] = 2
+        self.assertTrue("crotchDepth" in layer.smartComponentPoleMapping)
+        layer.smartComponentPoleMapping = {"shoulderWidth": 1}
+        self.assertFalse("crotchDepth" in layer.smartComponentPoleMapping)
+        self.assertEqual(1, layer.smartComponentPoleMapping["shoulderWidth"])
 
     # TODO: Methods
     # copyDecomposedLayer()

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -2184,6 +2184,42 @@ userData = {
 PartSelection = {
 height = 2;
 };
+com.typemytype.robofont.layerData = {
+"Regular Nov 6 15, 18:44" = {
+anchors = (
+);
+components = (
+{
+baseGlyph = tmA;
+transformation = (
+1,
+0,
+0,
+1,
+0,
+0
+);
+}
+);
+contours = (
+{
+points = (
+{
+smooth = 0;
+x = 2570;
+y = -907;
+}
+);
+}
+);
+lib = {
+};
+name = tmAA;
+unicodes = (
+);
+width = 3047;
+};
+};
 };
 width = 600;
 }

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -442,6 +442,9 @@ width = 593;
 leftKerningGroup = A;
 rightKerningGroup = A;
 unicode = 0041;
+script = "";
+category = "";
+subCategory = "";
 },
 {
 glyphname = Adieresis;

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -834,7 +834,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"352 147 LINE SMOOTH {\nname = Hello;\n}",
+"352 147 LINE SMOOTH {\nname = Hello;\nrememberToMakeCoffee = 1;\n}",
 "352 68 OFFCURVE",
 "314 7 OFFCURVE",
 "212 7 CURVE SMOOTH",

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -25,6 +25,12 @@ code = a.sc;
 name = smcp_target;
 }
 );
+customParameters = (
+{
+name = note;
+value = "Bla bla";
+}
+);
 date = "2015-06-08 08:53:00 +0000";
 familyName = "Glyphs Unit Test Sans";
 featurePrefixes = (

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -1060,8 +1060,144 @@ width = 518;
 unicode = 00E4;
 },
 {
+glyphname = h;
+lastChange = "2017-10-09 14:18:19 +0000";
+layers = (
+{
+components = (
+{
+name = _part.stem;
+piece = {
+height = 100;
+};
+},
+{
+name = _part.shoulder;
+piece = {
+crotchDepth = -80.20097;
+};
+}
+);
+layerId = "C4872ECA-A3A9-40AB-960A-1DB2202F16DE";
+width = 511;
+},
+{
+components = (
+{
+name = _part.stem;
+piece = {
+height = 100;
+};
+},
+{
+name = _part.shoulder;
+piece = {
+crotchDepth = -80.20097;
+};
+}
+);
+layerId = "3E7589AA-8194-470F-8E2F-13C1C581BE24";
+width = 532;
+},
+{
+components = (
+{
+name = _part.stem;
+piece = {
+height = 100;
+};
+},
+{
+name = _part.shoulder;
+piece = {
+crotchDepth = -80.20097;
+};
+}
+);
+layerId = "BFFFD157-90D3-4B85-B99D-9A2F366F03CA";
+width = 560;
+}
+);
+leftMetricsKey = m;
+rightMetricsKey = m;
+unicode = 0068;
+},
+{
+glyphname = m;
+lastChange = "2017-10-09 14:03:19 +0000";
+layers = (
+{
+components = (
+{
+name = _part.stem;
+},
+{
+name = _part.shoulder;
+piece = {
+shoulderWidth = 0;
+};
+},
+{
+name = _part.shoulder;
+piece = {
+shoulderWidth = 0;
+};
+transform = "{1, 0, 0, 1, 264, 0}";
+}
+);
+layerId = "C4872ECA-A3A9-40AB-960A-1DB2202F16DE";
+width = 745;
+},
+{
+components = (
+{
+name = _part.stem;
+},
+{
+name = _part.shoulder;
+piece = {
+shoulderWidth = 0;
+};
+},
+{
+name = _part.shoulder;
+piece = {
+shoulderWidth = 0;
+};
+transform = "{1, 0, 0, 1, 270, 0}";
+}
+);
+layerId = "BFFFD157-90D3-4B85-B99D-9A2F366F03CA";
+width = 820;
+},
+{
+components = (
+{
+name = _part.stem;
+},
+{
+name = _part.shoulder;
+piece = {
+shoulderWidth = 0;
+};
+},
+{
+name = _part.shoulder;
+piece = {
+shoulderWidth = 0;
+};
+transform = "{1, 0, 0, 1, 258, 0}";
+}
+);
+layerId = "3E7589AA-8194-470F-8E2F-13C1C581BE24";
+width = 760;
+}
+);
+unicode = 006D;
+},
+{
 glyphname = n;
-lastChange = "2016-03-23 16:55:38 +0000";
+lastChange = "2017-10-09 14:04:04 +0000";
 layers = (
 {
 background = {
@@ -1097,22 +1233,12 @@ nodes = (
 components = (
 {
 name = _part.shoulder;
+},
+{
+name = _part.stem;
 }
 );
 layerId = "BFFFD157-90D3-4B85-B99D-9A2F366F03CA";
-paths = (
-{
-closed = 1;
-nodes = (
-"181 385 LINE",
-"162 490 LINE",
-"30 490 LINE",
-"30 0 LINE",
-"250 0 LINE",
-"250 256 LINE"
-);
-}
-);
 width = 560;
 },
 {
@@ -1149,22 +1275,12 @@ nodes = (
 components = (
 {
 name = _part.shoulder;
+},
+{
+name = _part.stem;
 }
 );
 layerId = "3E7589AA-8194-470F-8E2F-13C1C581BE24";
-paths = (
-{
-closed = 1;
-nodes = (
-"149 393 LINE",
-"139 480 LINE",
-"77 480 LINE",
-"77 0 LINE",
-"167 0 LINE",
-"167 286 LINE"
-);
-}
-);
 width = 528;
 },
 {
@@ -1201,22 +1317,12 @@ nodes = (
 components = (
 {
 name = _part.shoulder;
+},
+{
+name = _part.stem;
 }
 );
 layerId = "C4872ECA-A3A9-40AB-960A-1DB2202F16DE";
-paths = (
-{
-closed = 1;
-nodes = (
-"119 368 LINE",
-"115 470 LINE",
-"100 470 LINE",
-"100 0 LINE",
-"117 0 LINE",
-"117 306 LINE"
-);
-}
-);
 width = 501;
 }
 );
@@ -1474,7 +1580,7 @@ unicode = 00A8;
 {
 export = 0;
 glyphname = _part.shoulder;
-lastChange = "2016-03-23 16:58:56 +0000";
+lastChange = "2017-10-09 13:47:55 +0000";
 layers = (
 {
 anchors = (
@@ -1512,6 +1618,12 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 2;
+shoulderWidth = 2;
+};
+};
 width = 501;
 },
 {
@@ -1550,6 +1662,12 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 2;
+shoulderWidth = 2;
+};
+};
 width = 528;
 },
 {
@@ -1588,6 +1706,12 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 2;
+shoulderWidth = 2;
+};
+};
 width = 560;
 },
 {
@@ -1628,6 +1752,12 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 2;
+shoulderWidth = 1;
+};
+};
 width = 501;
 },
 {
@@ -1668,6 +1798,12 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 1;
+shoulderWidth = 2;
+};
+};
 width = 501;
 },
 {
@@ -1708,6 +1844,12 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 2;
+shoulderWidth = 1;
+};
+};
 width = 528;
 },
 {
@@ -1748,6 +1890,12 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 1;
+shoulderWidth = 2;
+};
+};
 width = 528;
 },
 {
@@ -1788,6 +1936,12 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 2;
+shoulderWidth = 1;
+};
+};
 width = 560;
 },
 {
@@ -1828,7 +1982,219 @@ nodes = (
 );
 }
 );
+userData = {
+PartSelection = {
+crotchDepth = 1;
+shoulderWidth = 2;
+};
+};
 width = 560;
+}
+);
+partsSettings = (
+{
+name = crotchDepth;
+bottomName = Low;
+bottomValue = -100;
+topName = High;
+topValue = 0;
+},
+{
+name = shoulderWidth;
+bottomName = Low;
+bottomValue = 0;
+topName = High;
+topValue = 100;
+}
+);
+},
+{
+export = 0;
+glyphname = _part.stem;
+lastChange = "2017-10-09 14:18:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = connect;
+position = "{117, 0}";
+}
+);
+layerId = "C4872ECA-A3A9-40AB-960A-1DB2202F16DE";
+paths = (
+{
+closed = 1;
+nodes = (
+"119 368 LINE",
+"115 470 LINE",
+"100 470 LINE",
+"100 0 LINE",
+"117 0 LINE",
+"117 306 LINE"
+);
+}
+);
+userData = {
+PartSelection = {
+height = 1;
+};
+};
+width = 600;
+},
+{
+anchors = (
+{
+name = connect;
+position = "{167, 0}";
+}
+);
+layerId = "3E7589AA-8194-470F-8E2F-13C1C581BE24";
+paths = (
+{
+closed = 1;
+nodes = (
+"149 393 LINE",
+"139 480 LINE",
+"77 480 LINE",
+"77 0 LINE",
+"167 0 LINE",
+"167 286 LINE"
+);
+}
+);
+userData = {
+PartSelection = {
+height = 1;
+};
+};
+width = 600;
+},
+{
+anchors = (
+{
+name = connect;
+position = "{250, 0}";
+}
+);
+layerId = "BFFFD157-90D3-4B85-B99D-9A2F366F03CA";
+paths = (
+{
+closed = 1;
+nodes = (
+"181 385 LINE",
+"162 490 LINE",
+"30 490 LINE",
+"30 0 LINE",
+"250 0 LINE",
+"250 256 LINE"
+);
+}
+);
+userData = {
+PartSelection = {
+height = 1;
+};
+};
+width = 600;
+},
+{
+anchors = (
+{
+name = connect;
+position = "{117, 0}";
+}
+);
+associatedMasterId = "C4872ECA-A3A9-40AB-960A-1DB2202F16DE";
+layerId = "0D68D3E9-A0B2-4D78-A161-EB65D8511F0A";
+name = TallStem;
+paths = (
+{
+closed = 1;
+nodes = (
+"117 368 LINE",
+"117 800 LINE",
+"100 800 LINE",
+"100 0 LINE",
+"117 0 LINE",
+"117 306 LINE"
+);
+}
+);
+userData = {
+PartSelection = {
+height = 2;
+};
+};
+width = 600;
+},
+{
+anchors = (
+{
+name = connect;
+position = "{167, 0}";
+}
+);
+associatedMasterId = "3E7589AA-8194-470F-8E2F-13C1C581BE24";
+layerId = "3E1733D9-3B83-4E6A-B1E9-6381BBE1BD3A";
+name = TallStem;
+paths = (
+{
+closed = 1;
+nodes = (
+"167 393 LINE",
+"167 800 LINE",
+"77 800 LINE",
+"77 0 LINE",
+"167 0 LINE",
+"167 286 LINE"
+);
+}
+);
+userData = {
+PartSelection = {
+height = 2;
+};
+};
+width = 600;
+},
+{
+anchors = (
+{
+name = connect;
+position = "{250, 0}";
+}
+);
+associatedMasterId = "BFFFD157-90D3-4B85-B99D-9A2F366F03CA";
+layerId = "FD65D427-9013-43E2-9F74-398D99AA4763";
+name = TallStem;
+paths = (
+{
+closed = 1;
+nodes = (
+"250 385 LINE",
+"250 800 LINE",
+"30 800 LINE",
+"30 0 LINE",
+"250 0 LINE",
+"250 256 LINE"
+);
+}
+);
+userData = {
+PartSelection = {
+height = 2;
+};
+};
+width = 600;
+}
+);
+partsSettings = (
+{
+name = height;
+bottomName = Low;
+bottomValue = 0;
+topName = High;
+topValue = 100;
 }
 );
 }

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -280,7 +280,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"567 700 LINE",
+"566.99 700 LINE",
 "191 700 LINE",
 "24 0 LINE",
 "270 0 LINE",

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -2212,8 +2212,8 @@ weightClass = Thin;
 {
 interpolationWeight = 30;
 instanceInterpolations = {
-"C4872ECA-A3A9-40AB-960A-1DB2202F16DE" = 0.82192;
 "3E7589AA-8194-470F-8E2F-13C1C581BE24" = 0.17808;
+"C4872ECA-A3A9-40AB-960A-1DB2202F16DE" = 0.82192;
 };
 name = "Extra Light";
 weightClass = ExtraLight;

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -3359,6 +3359,16 @@ kerning = {
 keyboardIncrement = 0;
 unitsPerEm = 1000;
 userData = {
+AsteriskParameters = {
+"253E7231-480D-4F8E-8754-50FC8575C08E" = (
+"754",
+"30",
+7,
+51,
+"80",
+"50"
+);
+};
 GSDimensionPlugin.Dimensions = {
 "3E7589AA-8194-470F-8E2F-13C1C581BE24" = {
 HH = 91;

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -2212,8 +2212,8 @@ weightClass = Thin;
 {
 interpolationWeight = 30;
 instanceInterpolations = {
-"3E7589AA-8194-470F-8E2F-13C1C581BE24" = 0.17808;
 "C4872ECA-A3A9-40AB-960A-1DB2202F16DE" = 0.82192;
+"3E7589AA-8194-470F-8E2F-13C1C581BE24" = 0.17808;
 };
 name = "Extra Light";
 weightClass = ExtraLight;
@@ -3317,6 +3317,7 @@ kerning = {
 };
 };
 };
+keyboardIncrement = 0;
 unitsPerEm = 1000;
 userData = {
 GSDimensionPlugin.Dimensions = {

--- a/tests/interpolation_test.py
+++ b/tests/interpolation_test.py
@@ -26,7 +26,7 @@ import xml.etree.ElementTree as etree
 
 import defcon
 from fontTools.misc.py23 import open
-from glyphsLib.builder import GLYPHS_PREFIX
+from glyphsLib.builder.constants import GLYPHS_PREFIX
 from glyphsLib.interpolation import (
     build_designspace, set_weight_class, set_width_class, build_stylemap_names
 )

--- a/tests/interpolation_test.py
+++ b/tests/interpolation_test.py
@@ -120,6 +120,12 @@ class DesignspaceTest(unittest.TestCase):
         expectedPath = os.path.join(path, "data", expectedFile)
         with open(expectedPath, mode="r", encoding="utf-8") as f:
             expected = f.readlines()
+        if os.path.sep == '\\':
+            # On windows, the test must not fail because of a difference between
+            # forward and backward slashes in filname paths.
+            # The failure happens because of line 217 of "mutatorMath\ufo\document.py"
+            # > pathRelativeToDocument = os.path.relpath(fileName, os.path.dirname(self.path))
+            expected = [line.replace('filename="out/', 'filename="out\\') for line in expected]
         if actual != expected:
             for line in difflib.unified_diff(
                     expected, actual,

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -73,6 +73,24 @@ class ParserTest(unittest.TestCase):
             b'{mystr="Don\xe2\x80\x99t crash";}',
             [('mystr', 'Don’t crash')])
 
+    def test_parse_str_infinity(self):
+        self.run_test(
+            b'{mystr = infinity;}',
+            [('mystr', 'infinity')]
+        )
+
+    def test_parse_str_inf(self):
+        self.run_test(
+            b'{mystr = inf;}',
+            [('mystr', 'inf')]
+        )
+
+    def test_parse_str_nan(self):
+        self.run_test(
+            b'{mystr = nan;}',
+            [('mystr', 'nan')]
+        )
+
 
 GLYPH_ATTRIBUTES = {
     "bottomKerningGroup": str,

--- a/tests/roundtrip_test.py
+++ b/tests/roundtrip_test.py
@@ -19,8 +19,7 @@ import difflib
 import sys
 
 from glyphsLib import classes
-from glyphsLib.builder import to_ufos
-from glyphsLib.roundtrip import to_glyphs
+from glyphsLib.builder import (to_ufos, to_glyphs)
 
 import test_helpers
 

--- a/tests/roundtrip_test.py
+++ b/tests/roundtrip_test.py
@@ -1,0 +1,44 @@
+# coding=UTF-8
+#
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import difflib
+import sys
+
+from glyphsLib import classes
+from glyphsLib.builder import to_ufos
+from glyphsLib.roundtrip import to_glyphs
+
+import test_helpers
+
+
+class ClassRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):
+    def assertRoundtrip(self, font):
+        expected = test_helpers.write_to_lines(font)
+        roundtrip = to_glyphs(to_ufos(font))
+        actual = test_helpers.write_to_lines(roundtrip)
+        self.assertLinesEqual(
+            expected, actual,
+            "The font has been modified by the roundtrip")
+
+    def test_empty_font(self):
+        empty_font = classes.GSFont()
+        empty_font.masters.append(classes.GSFontMaster())
+        self.assertRoundtrip(empty_font)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/run_roundtrip_on_noto.py
+++ b/tests/run_roundtrip_on_noto.py
@@ -1,0 +1,50 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import os
+import unittest
+
+import test_helpers
+
+import glyphsLib
+
+NOTO_DIRECTORY = os.path.join(os.path.dirname(__file__), 'noto-source')
+
+def glyphs_files(directory):
+    for root, _dirs, files in os.walk(directory):
+        for filename in files:
+            if filename.endswith('.glyphs'):
+                yield os.path.join(root, filename)
+
+
+class NotoRoundtripTest(unittest.TestCase,
+                        test_helpers.AssertParseWriteRoundtrip):
+    pass
+
+
+if __name__ == '__main__':
+    subprocess.call([
+        "git", "clone", "https://github.com/googlei18n/noto-source.git",
+        NOTO_DIRECTORY])
+
+    for index, filename in enumerate(glyphs_files(NOTO_DIRECTORY)):
+        def test_method(self, filename=filename):
+            self.assertParseWriteRoundtrip(filename)
+        file_basename = os.path.basename(filename)
+        test_name = "test_{0}".format(file_basename.replace(r'[^a-zA-Z]', ''))
+        test_method.__name__ = test_name
+        setattr(NotoRoundtripTest, test_name, test_method)
+
+    unittest.main()

--- a/tests/run_roundtrip_on_noto.py
+++ b/tests/run_roundtrip_on_noto.py
@@ -19,8 +19,10 @@ import re
 
 import test_helpers
 
+NOTO_DIRECTORY = os.path.join(os.path.dirname(__file__), 'noto-source-moyogo')
+NOTO_GIT_URL = "https://github.com/moyogo/noto-source.git"
+NOTO_GIT_BRANCH = "normalized-1071"
 
-NOTO_DIRECTORY = os.path.join(os.path.dirname(__file__), 'noto-source')
 APP_VERSION_RE = re.compile('\\.appVersion = "(.*)"')
 
 
@@ -48,9 +50,9 @@ class NotoRoundtripTest(unittest.TestCase,
 if __name__ == '__main__':
     print("Run with `pytest -c noto_pytest.ini`")
 else:
-    subprocess.call([
-        "git", "clone", "https://github.com/googlei18n/noto-source.git",
-        NOTO_DIRECTORY])
+    subprocess.call(["git", "clone", NOTO_GIT_URL, NOTO_DIRECTORY])
+    subprocess.check_call(
+        ["git", "-C", NOTO_DIRECTORY, "checkout", NOTO_GIT_BRANCH])
 
     for index, filename in enumerate(glyphs_files(NOTO_DIRECTORY)):
         def test_method(self, filename=filename):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -52,7 +52,15 @@ class AssertParseWriteRoundtrip(AssertLinesEqual):
             f.seek(0, 0)
             font = glyphsLib.load(f)
         actual = write_to_lines(font)
+        # Roundtrip again to check idempotence
+        font = glyphsLib.loads("\n".join(actual))
+        actual_idempotent = write_to_lines(font)
+        # Assert idempotence first, because if that fails it's a big issue
+        self.assertLinesEqual(
+            actual, actual_idempotent,
+            "The parser/writer should be idempotent. BIG PROBLEM!")
         self.assertLinesEqual(
             expected, actual,
             "The writer should output exactly what the parser read")
+
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,7 +19,7 @@ import sys
 from textwrap import dedent
 
 import glyphsLib
-from glyphsLib.writer import GlyphsWriter
+from glyphsLib.writer import Writer
 from fontTools.misc.py23 import StringIO
 
 
@@ -29,7 +29,7 @@ def write_to_lines(glyphs_object):
     Return an array of lines ready for diffing.
     """
     string = StringIO()
-    writer = GlyphsWriter(fp=string)
+    writer = Writer(fp=string)
     writer.write(glyphs_object)
     return string.getvalue().splitlines()
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -69,4 +69,3 @@ class AssertParseWriteRoundtrip(AssertLinesEqual):
             expected, actual,
             "The writer should output exactly what the parser read")
 
-

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,44 @@
+# coding=UTF-8
+#
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import difflib
+import sys
+
+from glyphsLib.writer import GlyphsWriter
+from fontTools.misc.py23 import StringIO
+
+
+def write_to_lines(glyphs_object):
+    """
+    Use the Writer to write the given object to a StringIO.
+    Return an array of lines ready for diffing.
+    """
+    string = StringIO()
+    writer = GlyphsWriter(fp=string)
+    writer.write(glyphs_object)
+    return string.getvalue().splitlines()
+
+
+class AssertLinesEqual(object):
+    def assertLinesEqual(self, expected, actual, message):
+        if actual != expected:
+            for line in difflib.unified_diff(
+                    expected, actual,
+                    fromfile="<expected>", tofile="<actual>"):
+                if not line.endswith("\n"):
+                    line += "\n"
+                sys.stderr.write(line)
+            self.fail(message)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,6 +16,7 @@
 
 import difflib
 import sys
+from textwrap import dedent
 
 import glyphsLib
 from glyphsLib.writer import GlyphsWriter
@@ -36,6 +37,11 @@ def write_to_lines(glyphs_object):
 class AssertLinesEqual(object):
     def assertLinesEqual(self, expected, actual, message):
         if actual != expected:
+            if len(actual) < len(expected):
+                sys.stderr.write(dedent("""\
+                    WARNING: the actual text is shorter that the expected text.
+                             Some information may be LOST!
+                    """))
             for line in difflib.unified_diff(
                     expected, actual,
                     fromfile="<expected>", tofile="<actual>"):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,6 +17,7 @@
 import difflib
 import sys
 
+import glyphsLib
 from glyphsLib.writer import GlyphsWriter
 from fontTools.misc.py23 import StringIO
 
@@ -42,3 +43,16 @@ class AssertLinesEqual(object):
                     line += "\n"
                 sys.stderr.write(line)
             self.fail(message)
+
+
+class AssertParseWriteRoundtrip(AssertLinesEqual):
+    def assertParseWriteRoundtrip(self, filename):
+        with open(filename) as f:
+            expected = f.read().splitlines()
+            f.seek(0, 0)
+            font = glyphsLib.load(f)
+        actual = write_to_lines(font)
+        self.assertLinesEqual(
+            expected, actual,
+            "The writer should output exactly what the parser read")
+

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -595,9 +595,11 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             userData = {
             rememberToMakeCoffe = 1;
             };
-            smartComponentAxes = (
+            partsSettings = (
             {
             name = crotchDepth;
+            bottomValue = 0;
+            topValue = 0;
             }
             );
             }
@@ -775,13 +777,17 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         axis = classes.GSSmartComponentAxis()
         # http://docu.glyphsapp.com/#gssmartcomponentaxis
         axis.name = "crotchDepth"
+        axis.topName = "High"
         axis.topValue = 0
+        axis.bottomName = "Low"
         axis.bottomValue = -100
-        # FIXME: (jany) keys that have value 0 are not written?
         self.assertWrites(axis, dedent("""\
             {
-            bottomValue = -100;
             name = crotchDepth;
+            bottomName = Low;
+            bottomValue = -100;
+            topName = High;
+            topValue = 0;
             }
         """))
 

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -720,6 +720,10 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
             );
             userData = {
+            PartSelection = {
+            crotchDepth = 2;
+            shoulderWidth = 1;
+            };
             rememberToMakeCoffe = 1;
             };
             width = 890.4;

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -478,6 +478,19 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             classes.GSCustomParameter('fsType', [1, 2]),
             "{\nname = fsType;\nvalue = (\n1,\n2\n);\n}")
 
+    def test_write_class(self):
+        _class = classes.GSClass()
+        _class.name = "e"
+        _class.code = "e eacute egrave"
+        _class.automatic = True
+        self.assertWrites(_class, dedent("""\
+            {
+            automatic = 1;
+            code = "e eacute egrave";
+            name = e;
+            }
+        """))
+
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be
 # formatted exactly like what this writer outputs

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -26,6 +26,7 @@ from glyphsLib.types import glyphs_datetime
 import test_helpers
 
 class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
+
     def assertWrites(self, glyphs_object, text):
         """Assert that the given object, when given to the writer,
         produces the given text.
@@ -34,6 +35,19 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         actual = test_helpers.write_to_lines(glyphs_object)
         # print(expected)
         # print(actual)
+        self.assertLinesEqual(
+            expected, actual,
+            "The writer has not produced the expected output")
+
+    def assertWritesValue(self, glyphs_value, text):
+        """Assert that the writer produces the given text for the given value."""
+        expected = dedent("""\
+        {{
+        writtenValue = {0};
+        }}
+        """).format(text).splitlines()
+        # We wrap the value in a dict to use the same test helper
+        actual = test_helpers.write_to_lines({'writtenValue': glyphs_value})
         self.assertLinesEqual(
             expected, actual,
             "The writer has not produced the expected output")
@@ -338,6 +352,9 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+    def test_write_alignment_zone(self):
+        zone = classes.GSAlignmentZone(23, 40)
+        self.assertWritesValue(zone, '"{23, 40}"')
 
 # Might be impractical because of formatting (whitespace changes)
 # class WriterRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -235,8 +235,8 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
-        # Don't write the keyboardIncrement if it's None
-        font.keyboardIncrement = None
+        # Don't write the keyboardIncrement if it's 1 (default)
+        font.keyboardIncrement = 1
         written = test_helpers.write_to_lines(font)
         self.assertFalse(any("keyboardIncrement" in line for line in written))
 

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -26,7 +26,7 @@ from glyphsLib.types import glyphs_datetime
 import test_helpers
 
 class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
-    def assertWritten(self, glyphs_object, text):
+    def assertWrites(self, glyphs_object, text):
         """Assert that the given object, when given to the writer,
         produces the given text.
         """
@@ -151,7 +151,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # .appVersion (extra property that is not in the docs!)
         font.appVersion = 895
         # TODO: (jany) check that node and ascender are correctly stored
-        self.assertWritten(font, dedent("""\
+        self.assertWrites(font, dedent("""\
             {
             .appVersion = 895;
             classes = (
@@ -225,7 +225,119 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
-    # TODO: (jany) same for each GS class
+    def test_write_font_master_attributes(self):
+        """Test the writer on all GSFontMaster attributes"""
+        master = classes.GSFontMaster()
+        # List of properties from https://docu.glyphsapp.com/#gsfontmaster
+        # id
+        master.id = "MASTER-ID"
+        # name
+        master.name = "Hairline Megawide"
+        # weight
+        master.weight = "Thin"
+        # width
+        master.width = "Wide"
+        # weightValue
+        master.weightValue = 0.01
+        # widthValue
+        master.widthValue = 0.99
+        # customValue
+        # customName
+        # FIXME: (jany) Why is it called "custom" here instead of "customName"?
+        master.custom = "cuteness"
+        # FIXME: (jany) A value of 0.0 is not written to the file.
+        master.customValue = 0.001
+        # FIXME: (jany) Why are there 3 more customValues?
+        master.custom1 = "color"
+        master.customValue1 = 0.1
+        master.custom2 = "depth"
+        master.customValue2 = 0.2
+        master.custom3 = "surealism"
+        master.customValue3 = 0.3
+        # ascender
+        master.ascender = 234.5
+        # capHeight
+        master.capHeight = 200.6
+        # xHeight
+        master.xHeight = 59.1
+        # descender
+        master.descender = -89.2
+        # italicAngle
+        master.italicAngle = 12.2
+        # verticalStems
+        master.verticalStems = [1, 2, 3]
+        # horizontalStems
+        master.horizontalStems = [4, 5, 6]
+        # alignmentZones
+        zone = classes.GSAlignmentZone(0, -30)
+        master.alignmentZones = [
+            zone
+        ]
+        # blueValues: not handled because it is read-only
+        # otherBlues: not handled because it is read-only
+        # guides
+        # FIXME: (jany) Here it is called "guideLines" instead of "guides"
+        guide = classes.GSGuideLine()
+        guide.name = "middle"
+        master.guideLines.append(guide)
+        # userData
+        master.userData['rememberToMakeTea'] = True
+        # customParameters
+        master.customParameters['underlinePosition'] = -135
+        self.assertWrites(master, dedent("""\
+            {
+            alignmentZones = (
+            "{0, -30}"
+            );
+            ascender = 234.5;
+            capHeight = 200.6;
+            custom = cuteness;
+            customValue = 0.001;
+            custom1 = color;
+            customValue1 = 0.1;
+            custom2 = depth;
+            customValue2 = 0.2;
+            custom3 = surealism;
+            customValue3 = 0.3;
+            customParameters = (
+            {
+            name = "Master Name";
+            value = "Hairline Megawide";
+            },
+            {
+            name = underlinePosition;
+            value = -135;
+            }
+            );
+            descender = -89.2;
+            guideLines = (
+            {
+            name = middle;
+            }
+            );
+            horizontalStems = (
+            4,
+            5,
+            6
+            );
+            id = "MASTER-ID";
+            italicAngle = 12.2;
+            userData = {
+            rememberToMakeTea = 1;
+            };
+            verticalStems = (
+            1,
+            2,
+            3
+            );
+            weight = Thin;
+            weightValue = 0.01;
+            width = Wide;
+            widthValue = 0.99;
+            xHeight = 59.1;
+            }
+        """))
+
 
 # Might be impractical because of formatting (whitespace changes)
 # class WriterRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -450,6 +450,36 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+    def test_write_custom_parameter(self):
+        # Name without quotes
+        self.assertWritesValue(
+            classes.GSCustomParameter('myParam', 'myValue'),
+            "{\nname = myParam;\nvalue = myValue;\n}")
+        # Name with quotes
+        self.assertWritesValue(
+            classes.GSCustomParameter('my param', 'myValue'),
+            "{\nname = \"my param\";\nvalue = myValue;\n}")
+        # Value with quotes
+        self.assertWritesValue(
+            classes.GSCustomParameter('myParam', 'my value'),
+            "{\nname = myParam;\nvalue = \"my value\";\n}")
+        # Int param (ascender): should convert the value to string
+        self.assertWritesValue(
+            classes.GSCustomParameter('ascender', 12),
+            "{\nname = ascender;\nvalue = 12;\n}")
+        # Float param (postscriptBlueScale): should convert the value to string
+        self.assertWritesValue(
+            classes.GSCustomParameter('postscriptBlueScale', 0.125),
+            "{\nname = postscriptBlueScale;\nvalue = 0.125;\n}")
+        # Bool param (isFixedPitch): should convert the boolean value to 0/1
+        self.assertWritesValue(
+            classes.GSCustomParameter('isFixedPitch', True),
+            "{\nname = isFixedPitch;\nvalue = 1;\n}")
+        # Intlist param: should map list of int to list of strings
+        self.assertWritesValue(
+            classes.GSCustomParameter('fsType', [1, 2]),
+            "{\nname = fsType;\nvalue = (\n1,\n2\n);\n}")
+
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be
 # formatted exactly like what this writer outputs

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -66,7 +66,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         font.instances.append(i1)
         # glyphs
         g1 = classes.GSGlyph()
-        g1.id = 'G1'
+        g1.name = 'G1'
         font.glyphs.append(g1)
         # classes
         c1 = classes.GSClass()
@@ -197,6 +197,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             );
             glyphs = (
             {
+            glyphname = G1;
             }
             );
             grid = 35;
@@ -491,7 +492,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
-    def test_feature_prefix(self):
+    def test_write_feature_prefix(self):
         fp = classes.GSFeaturePrefix()
         fp.name = "Languagesystems"
         fp.code = "languagesystem DFLT dflt;"
@@ -504,7 +505,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
-    def test_feature(self):
+    def test_write_feature(self):
         feature = classes.GSFeature()
         feature.name = "sups"
         feature.code = "    sub @standard by @sups;"
@@ -519,6 +520,79 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+    def test_write_glyph(self):
+        glyph = classes.GSGlyph()
+        # https://docu.glyphsapp.com/#gsglyph
+        # parent: not written
+        # layers
+        layer = classes.GSLayer()
+        layer.name = "L1"
+        # TODO: (jany) manipulate layer without a parent?
+        # glyph.layers.append(layer)
+        # name
+        glyph.name = "Aacute"
+        # unicode
+        glyph.unicode = "00C1"
+        # string: not written
+        # id: not written
+        # category
+        glyph.category = "Letter"
+        # subCategory
+        glyph.subCategory = "Uppercase"
+        # script
+        glyph.script = "latin"
+        # productionName
+        glyph.productionName = "Aacute.prod"
+        # glyphInfo: not written
+        # leftKerningGroup
+        glyph.leftKerningGroup = "A"
+        # rightKerningGroup
+        glyph.rightKerningGroup = "A"
+        # leftKerningKey: not written
+        # rightKerningKey: not written
+        # leftMetricsKey
+        glyph.leftMetricsKey = "A"
+        # rightMetricsKey
+        glyph.rightMetricsKey = "A"
+        # widthMetricsKey
+        glyph.widthMetricsKey = "A"
+        # export
+        glyph.export = False
+        # color
+        glyph.color = 11
+        # colorObject: not written
+        # note
+        glyph.note = "Stunning one-bedroom A with renovated acute accent"
+        # selected: FIXME: (jany) not written?
+        # mastersCompatible: not stored
+        # userData
+        glyph.userData['rememberToMakeCoffe'] = True
+        # smartComponentAxes
+        # TODO: GSSmartComponentAxis
+        glyph.smartComponentAxes = []
+        # lastChange
+        glyph.lastChange = glyphs_datetime('2017-10-03 07:35:46 +0000')
+        self.assertWrites(glyph, dedent("""\
+            {
+            color = 11;
+            export = 0;
+            glyphname = Aacute;
+            lastChange = "2017-10-03 07:35:46 +0000";
+            leftKerningGroup = A;
+            leftMetricsKey = A;
+            widthMetricsKey = A;
+            note = "Stunning one-bedroom A with renovated acute accent";
+            rightKerningGroup = A;
+            rightMetricsKey = A;
+            unicode = 00C1;
+            script = latin;
+            category = Letter;
+            subCategory = Uppercase;
+            userData = {
+            rememberToMakeCoffe = 1;
+            };
+            }
+        """))
 
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -131,31 +131,18 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         font.disablesNiceNames = True
         # customParameters
         font.customParameters['ascender'] = 300
-        # selection
-        # FIXME: (jany) Not writable here: instead, check that individual
-        #   glyphs store their "selected" status correctly
-        # font.selection = ?
-        # selectedLayers
-        # FIXME: (jany) Same as `selection`
-        # selectedFontMaster
-        # FIXME: (jany) Same as `selection`
-        # masterIndex
-        # FIXME: (jany) Same as `selection`
-        # currentText
-        # FIXME: (jany) Same as `selection`
-        # tabs
-        # FIXME: (jany) Same as `selection`
-        # currentTab
-        # FIXME: (jany) Same as `selection`
-        # filepath
-        # FIXME: (jany) not handled because the GSFont should be able
-        #   to be written anywhere on the disk once it has been loaded?
-        # tool
-        # FIXME: (jany) Same as `selection`
+        # selection: not written
+        # selectedLayers: not written
+        # selectedFontMaster: not written
+        # masterIndex: not written
+        # currentText: not written
+        # tabs: not written
+        # currentTab: not written
+        # filepath: not written
+        # tool: not written
         # tools: not handled because it is a read-only list of GUI features
         # .appVersion (extra property that is not in the docs!)
         font.appVersion = 895
-        # TODO: (jany) check that node and ascender are correctly stored
         self.assertWrites(font, dedent("""\
             {
             .appVersion = 895;
@@ -271,11 +258,9 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         master.widthValue = 0.99
         # customValue
         # customName
-        # FIXME: (jany) Why is it called "custom" here instead of "customName"?
-        master.custom = "cuteness"
-        # FIXME: (jany) A value of 0.0 is not written to the file.
+        master.customName = "cuteness"
+        # A value of 0.0 is not written to the file.
         master.customValue = 0.001
-        # FIXME: (jany) Why are there 3 more customValues?
         master.custom1 = "color"
         master.customValue1 = 0.1
         master.custom2 = "depth"
@@ -304,10 +289,9 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # blueValues: not handled because it is read-only
         # otherBlues: not handled because it is read-only
         # guides
-        # FIXME: (jany) Here it is called "guideLines" instead of "guides"
         guide = classes.GSGuideLine()
         guide.name = "middle"
-        master.guideLines.append(guide)
+        master.guides.append(guide)
         # userData
         master.userData['rememberToMakeTea'] = True
         # customParameters
@@ -390,9 +374,9 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # width
         instance.width = "Compressed (width)"
         # weightValue
-        instance.weightValue = 0.6
+        instance.weightValue = 600
         # widthValue
-        instance.widthValue = 0.2
+        instance.widthValue = 200
         # customValue
         instance.customValue = 0.4
         # isItalic
@@ -427,7 +411,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # interpolatedFont: read only
 
         # FIXME: (jany) the weight and width are not in the output
-        #   cofusion with weightClass/widthClass?
+        #   confusion with weightClass/widthClass?
         self.assertWrites(instance, dedent("""\
             {
             customParameters = (
@@ -461,8 +445,8 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
             );
             interpolationCustom = 0.4;
-            interpolationWeight = 0.6;
-            interpolationWidth = 0.2;
+            interpolationWeight = 600;
+            interpolationWidth = 200;
             instanceInterpolations = {
             M1 = 0.2;
             M2 = 0.8;
@@ -561,10 +545,17 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # https://docu.glyphsapp.com/#gsglyph
         # parent: not written
         # layers
+        # Put the glyph in a font with at least one master for the magic in
+        # `glyph.layers.append()` to work.
+        font = classes.GSFont()
+        master = classes.GSFontMaster()
+        master.id = "MASTER-ID"
+        font.masters.insert(0, master)
+        font.glyphs.append(glyph)
         layer = classes.GSLayer()
+        layer.layerId = "LAYER-ID"
         layer.name = "L1"
-        # TODO: (jany) manipulate layer without a parent?
-        # glyph.layers.append(layer)
+        glyph.layers.insert(0, layer)
         # name
         glyph.name = "Aacute"
         # unicode
@@ -599,7 +590,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # colorObject: not written
         # note
         glyph.note = "Stunning one-bedroom A with renovated acute accent"
-        # selected: FIXME: (jany) not written?
+        # selected: not written
         # mastersCompatible: not stored
         # userData
         glyph.userData['rememberToMakeCoffe'] = True
@@ -624,13 +615,20 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         glyph.smartComponentAxes.append(axis)
         # lastChange
         glyph.lastChange = glyphs_datetime('2017-10-03 07:35:46 +0000')
-        # FIXME: (jany) not sure about the key name for smartComponentAxes
         self.assertWrites(glyph, dedent("""\
             {
             color = 11;
             export = 0;
             glyphname = Aacute;
             lastChange = "2017-10-03 07:35:46 +0000";
+            layers = (
+            {
+            associatedMasterId = "MASTER-ID";
+            layerId = "LAYER-ID";
+            name = L1;
+            width = 0;
+            }
+            );
             leftKerningGroup = A;
             leftMetricsKey = A;
             widthMetricsKey = A;
@@ -704,8 +702,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         layer.guides.append(guide)
         # annotations
         annotation = classes.GSAnnotation()
-        # annotation.type = TEXT  # FIXME: (jany) this constant from the doc's examples is not defined
-        annotation.type = 'TEXT'
+        annotation.type = classes.TEXT
         annotation.text = 'Fuck, this curve is ugly!'
         layer.annotations.append(annotation)
         # hints
@@ -761,7 +758,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             {
             position = ;
             text = "Fuck, this curve is ugly!";
-            type = TEXT;
+            type = 1;
             }
             );
             associatedMasterId = M1;
@@ -964,7 +961,6 @@ rememberToDownloadARealRemindersApp = 1;\\n}"'
     def test_write_hint(self):
         hint = classes.GSHint()
         # http://docu.glyphsapp.com/#gshint
-        # FIXME: (jany) understand how hints are stored
         layer = classes.GSLayer()
         path1 = classes.GSPath()
         layer.paths.append(path1)
@@ -1007,7 +1003,13 @@ rememberToDownloadARealRemindersApp = 1;\\n}"'
         # FIXME: (jany) What about the undocumented scale & stem?
         #   -> Add a test for that
 
-        # FIXME: (jany) Add a test for target = "up"?
+        # Test with target = "up"
+        # FIXME: (jany) what does target = "up" mean?
+        #   Is there an official python API to write that?
+        # hint.targetNode = 'up'
+        # written = test_helpers.write_to_lines(hint)
+        # self.assertIn('target = up;', written)
+
 
     def test_write_background_image(self):
         image = classes.GSBackgroundImage('/tmp/img.jpg')

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -356,7 +356,107 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         zone = classes.GSAlignmentZone(23, 40)
         self.assertWritesValue(zone, '"{23, 40}"')
 
-# Might be impractical because of formatting (whitespace changes)
+    def test_write_instance(self):
+        instance = classes.GSInstance()
+        # List of properties from https://docu.glyphsapp.com/#gsinstance
+        # active
+        # FIXME: (jany) does not seem to be handled by this library? No doc?
+        instance.active = True
+        # name
+        instance.name = "SemiBoldCompressed (name)"
+        # weight
+        instance.weight = "SemiBold (weight)"
+        # width
+        instance.width = "Compressed (width)"
+        # weightValue
+        instance.weightValue = 0.6
+        # widthValue
+        instance.widthValue = 0.2
+        # customValue
+        instance.customValue = 0.4
+        # isItalic
+        instance.isItalic = True
+        # isBold
+        instance.isBold = True
+        # linkStyle
+        instance.linkStyle = "linked style value"
+        # familyName
+        instance.familyName = "Sans Rien (familyName)"
+        # preferredFamily
+        instance.preferredFamily = "Sans Rien (preferredFamily)"
+        # preferredSubfamilyName
+        instance.preferredSubfamilyName = "Semi Bold Compressed (preferredSubFamilyName)"
+        # windowsFamily
+        instance.windowsFamily = "Sans Rien MS (windowsFamily)"
+        # windowsStyle: read only
+        # windowsLinkedToStyle: read only
+        # fontName
+        instance.fontName = "SansRien (fontName)"
+        # fullName
+        instance.fullName = "Sans Rien Semi Bold Compressed (fullName)"
+        # customParameters
+        instance.customParameters['hheaLineGap'] = 10
+        # instanceInterpolations
+        instance.instanceInterpolations = {
+            'M1': 0.2,
+            'M2': 0.8
+        }
+        # manualInterpolation
+        instance.manualInterpolation = True
+        # interpolatedFont: read only
+
+        # FIXME: (jany) the weight and width are not in the output
+        #   cofusion with weightClass/widthClass?
+        self.assertWrites(instance, dedent("""\
+            {
+            customParameters = (
+            {
+            name = famiyName;
+            value = "Sans Rien (familyName)";
+            },
+            {
+            name = preferredFamily;
+            value = "Sans Rien (preferredFamily)";
+            },
+            {
+            name = preferredSubfamilyName;
+            value = "Semi Bold Compressed (preferredSubFamilyName)";
+            },
+            {
+            name = styleMapFamilyName;
+            value = "Sans Rien MS (windowsFamily)";
+            },
+            {
+            name = postscriptFontName;
+            value = "SansRien (fontName)";
+            },
+            {
+            name = postscriptFullName;
+            value = "Sans Rien Semi Bold Compressed (fullName)";
+            },
+            {
+            name = hheaLineGap;
+            value = 10;
+            }
+            );
+            interpolationCustom = 0.4;
+            interpolationWeight = 0.6;
+            interpolationWidth = 0.2;
+            instanceInterpolations = {
+            M1 = 0.2;
+            M2 = 0.8;
+            };
+            isBold = 1;
+            isItalic = 1;
+            linkStyle = "linked style value";
+            manualInterpolation = 1;
+            name = "SemiBoldCompressed (name)";
+            }
+        """))
+
+# Might be impractical because of formatting (whitespace changes)?
+# Maybe it's OK because random glyphs files from github seem to be
+# formatted exactly like what this writer outputs
 # class WriterRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):
 #     def assertParseWriteRoundtrip(self, filename):
 #         with open(filename) as f:

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -570,9 +570,12 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         glyph.userData['rememberToMakeCoffe'] = True
         # smartComponentAxes
         # TODO: GSSmartComponentAxis
-        glyph.smartComponentAxes = []
+        axis = classes.GSSmartComponentAxis()
+        axis.name = "crotchDepth"
+        glyph.smartComponentAxes.append(axis)
         # lastChange
         glyph.lastChange = glyphs_datetime('2017-10-03 07:35:46 +0000')
+        # FIXME: (jany) not sure about the key name for smartComponentAxes
         self.assertWrites(glyph, dedent("""\
             {
             color = 11;
@@ -592,6 +595,11 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             userData = {
             rememberToMakeCoffe = 1;
             };
+            smartComponentAxes = (
+            {
+            name = crotchDepth;
+            }
+            );
             }
         """))
 

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -808,6 +808,27 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+    def test_write_node(self):
+        node = classes.GSNode(point(10, 30), classes.GSNode.CURVE)
+        # http://docu.glyphsapp.com/#gsnode
+        # position: already set
+        # type: already set
+        # smooth
+        node.smooth = True
+        # connection: deprecated
+        # selected: not written
+        # index, nextNode, prevNode: computed
+        # name
+        node.name = "top-left corner"
+        # userData
+        # FIXME: (jany) The user data is missing!
+        node.userData["rememberToDownloadARealRemindersApp"] = True
+        self.assertWritesValue(
+            node,
+            '"10 30 CURVE SMOOTH {\\nname = \\"top-left corner\\";\\n\
+userData = {\\nrememberToDownloadARealRemindersApp = 1;\\n};\\n}"'
+        )
+
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be
 # formatted exactly like what this writer outputs

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import unittest
+import math
 from textwrap import dedent
 from collections import OrderedDict
 
@@ -723,6 +724,45 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             position = "{23, 45.5}";
             }
         """))
+
+    def test_write_component(self):
+        component = classes.GSComponent("dieresis")
+        # http://docu.glyphsapp.com/#gscomponent
+        # position
+        component.position = point(45.5, 250)
+        # scale
+        component.scale = 2.0
+        # rotation
+        component.rotation = math.pi/2
+        # componentName: already set at init
+        # component: read-only
+        # layer: read-only
+        # transform: already set using scale & position
+        # FIXME: (jany) the results don't look very precise:
+        #   with an integer scale and 90° rotation, the resulting matrix
+        #   should have integer coefficients?
+        # bounds: read-only, objective-c
+        # automaticAlignment
+        component.automaticAlignment = True
+        # anchor
+        component.anchor = "top"
+        # selected: not written
+        # smartComponentValues
+        component.smartComponentValues = {
+            "crotchDepth": -77,
+        }
+        # bezierPath: read-only, objective-c
+        self.assertWrites(component, dedent("""\
+            {
+            anchor = top;
+            name = dieresis;
+            smartComponentValues = {
+            crotchDepth = -77;
+            };
+            transform = "{1.99925, 0.05482, -0.05482, 1.99925, 45.5, 250}";
+            }
+        """))
+
 
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -355,6 +355,13 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+        # Write the capHeight and xHeight even if they are "0"
+        master.xHeight = 0
+        master.capHeight = 0
+        written = test_helpers.write_to_lines(master)
+        self.assertIn("xHeight = 0;", written)
+        self.assertIn("capHeight = 0;", written)
+
     def test_write_alignment_zone(self):
         zone = classes.GSAlignmentZone(23, 40)
         self.assertWritesValue(zone, '"{23, 40}"')

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -17,9 +17,11 @@
 import unittest
 import datetime
 from textwrap import dedent
+from collections import OrderedDict
 
 import glyphsLib
 from glyphsLib import classes
+from glyphsLib.types import glyphs_datetime
 
 import test_helpers
 
@@ -37,20 +39,193 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             "The writer has not produced the expected output")
 
     def test_write_font_attributes(self):
+        """Test the writer on all GSFont attributes"""
         font = classes.GSFont()
+        # List of properties from https://docu.glyphsapp.com/#gsfont
+        # parent: not handled because it's internal and read-only
+        # masters
+        m1 = classes.GSFontMaster()
+        m1.id = "M1"
+        font.masters.insert(0, m1)
+        m2 = classes.GSFontMaster()
+        m2.id = "M2"
+        font.masters.insert(1, m2)
+        # instances
+        i1 = classes.GSInstance()
+        i1.name = "MuchBold"
+        font.instances.append(i1)
+        # glyphs
+        g1 = classes.GSGlyph()
+        g1.id = 'G1'
+        font.glyphs.append(g1)
+        # classes
+        c1 = classes.GSClass()
+        c1.name = "C1"
+        font.classes.append(c1)
+        # features
+        f1 = classes.GSFeature()
+        f1.name = "F1"
+        font.features.append(f1)
+        # featurePrefixes
+        fp1 = classes.GSFeaturePrefix()
+        fp1 = "FP1"
+        font.featurePrefixes.append(fp1)
+        # copyright
+        font.copyright = "Copyright Bob"
+        # designer
+        font.designer = "Bob"
+        # designerURL
+        font.designerURL = "bob.me"
+        # manufacturer
+        font.manufacturer = "Manu"
+        # manufacturerURL
+        font.manufacturerURL = "manu.com"
+        # versionMajor
+        font.versionMajor = 2
+        # versionMinor
+        font.versionMinor = 104
+        # date
+        font.date = glyphs_datetime('2017-10-03 07:35:46 +0000')
+        # familyName
+        font.familyName = "Sans Rien"
+        # upm
+        # FIXME: (jany) In this library it is called "unitsPerEm"
+        # font.upm = 2000
+        font.unitsPerEm = 2000
+        # note
+        font.note = "Was bored, made this"
+        # kerning
+        font.kerning = OrderedDict([
+            ('M1', OrderedDict([
+                ('@MMK_L_G1', OrderedDict([
+                    ('@MMK_R_G1', 0.1)
+                ]))
+            ]))
+        ])
+        # userData
+        font.userData = {
+            'a': 'test',
+            'b': [1, {'c': 2}]
+        }
+        # grid
+        font.grid = 35
+        # gridSubDivisions
+        # FIXME: (jany) In this library it is called "gridSubDivision" (no s)
+        font.gridSubDivisions = 5
+        # gridLength
+        font.gridLength = 2
+        # keyboardIncrement
+        # FIXME: (jany) Not handled by this library, maybe because it's a
+        #   UI feature from Glyphs.app. It should be handled though, so that
+        #   designers who use the export/import macros don't lose their settings?
+        font.keyboardIncrement = 1.2
+        # disablesNiceNames
+        font.disablesNiceNames = True
+        # customParameters
+        font.customParameters['ascender'] = 300
+        # selection
+        # FIXME: (jany) Not handled by this library.
+        #   Not sure that it makes sense to handle it, because the selection
+        #   sounds like a very impermanent thing that will not be expected to
+        #   be restored after an export/import to UFO.
+        #   Maybe it would still be nice to have? TODO: ask a designer?
+        # font.selection = ?
+        # selectedLayers
+        # FIXME: (jany) Same as `selection`
+        # selectedFontMaster
+        # FIXME: (jany) Same as `selection`
+        # masterIndex
+        # FIXME: (jany) Same as `selection`
+        # currentText
+        # FIXME: (jany) Same as `selection`
+        # tabs
+        # FIXME: (jany) Same as `selection`
+        # currentTab
+        # FIXME: (jany) Same as `selection`
+        # filepath
+        # FIXME: (jany) not handled because the GSFont should be able
+        #   to be written anywhere on the disk once it has been loaded?
+        # tool
+        # FIXME: (jany) Same as `selection`
+        # tools: not handled because it is a read-only list of GUI features
+        # .appVersion (extra property that is not in the docs!)
         font.appVersion = 895
-        font.date = datetime.datetime(2017, 10, 3, 7, 35, 46, 897234)
-        font.familyName = 'MyFont'
+        # TODO: (jany) check that node and ascender are correctly stored
         self.assertWritten(font, dedent("""\
             {
             .appVersion = 895;
-            date = "2017-10-03 07:35:46.897234 +0000";
-            familyName = MyFont;
-            versionMajor = 1;
-            versionMinor = 0;
+            classes = (
+            {
+            name = C1;
+            }
+            );
+            copyright = "Copyright Bob";
+            customParameters = (
+            {
+            name = note;
+            value = "Was bored, made this";
+            },
+            {
+            name = ascender;
+            value = 300;
+            }
+            );
+            date = "2017-10-03 07:35:46 +0000";
+            designer = Bob;
+            designerURL = bob.me;
+            disablesNiceNames = 1;
+            familyName = "Sans Rien";
+            featurePrefixes = (
+            FP1
+            );
+            features = (
+            {
+            name = F1;
+            }
+            );
+            fontMaster = (
+            {
+            id = M1;
+            },
+            {
+            id = M2;
+            }
+            );
+            glyphs = (
+            {
+            }
+            );
+            grid = 35;
+            gridLength = 2;
+            instances = (
+            {
+            name = MuchBold;
+            }
+            );
+            kerning = {
+            M1 = {
+            "@MMK_L_G1" = {
+            "@MMK_R_G1" = 0.1;
+            };
+            };
+            };
+            manufacturer = Manu;
+            manufacturerURL = manu.com;
+            userData = {
+            a = test;
+            b = (
+            1,
+            {
+            c = 2;
+            }
+            );
+            };
+            versionMajor = 2;
+            versionMinor = 104;
             }
         """))
 
+    # TODO: (jany) same for each GS class
 
 # Might be impractical because of formatting (whitespace changes)
 # class WriterRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -491,6 +491,20 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+    def test_feature_prefix(self):
+        fp = classes.GSFeaturePrefix()
+        fp.name = "sups"
+        fp.code = "    sub @standard by @sups;"
+        fp.automatic = True
+        self.assertWrites(fp, dedent("""\
+            {
+            automatic = 1;
+            code = "    sub @standard by @sups;";
+            name = sups;
+            }
+        """))
+
+
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be
 # formatted exactly like what this writer outputs

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -116,7 +116,8 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # userData
         font.userData = {
             'a': 'test',
-            'b': [1, {'c': 2}]
+            'b': [1, {'c': 2}],
+            'd': [1, "1"],
         }
         # grid
         font.grid = 35
@@ -228,6 +229,10 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             {
             c = 2;
             }
+            );
+            d = (
+            1,
+            "1"
             );
             };
             versionMajor = 2;

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -19,7 +19,7 @@ from textwrap import dedent
 from collections import OrderedDict
 
 from glyphsLib import classes
-from glyphsLib.types import glyphs_datetime
+from glyphsLib.types import glyphs_datetime, point
 
 import test_helpers
 
@@ -712,6 +712,15 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             rememberToMakeCoffe = 1;
             };
             width = 890.4;
+            }
+        """))
+
+    def test_write_anchor(self):
+        anchor = classes.GSAnchor('top', point(23, 45.5))
+        self.assertWrites(anchor, dedent("""\
+            {
+            name = top;
+            position = "{23, 45.5}";
             }
         """))
 

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -967,17 +967,8 @@ rememberToDownloadARealRemindersApp = 1;\\n}"'
         """))
 
 
-class WriterRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):
-    def assertParseWriteRoundtrip(self, filename):
-        with open(filename) as f:
-            expected = f.read().splitlines()
-            f.seek(0, 0)
-            font = glyphsLib.load(f)
-        actual = test_helpers.write_to_lines(font)
-        self.assertLinesEqual(
-            expected, actual,
-            "The writer should output exactly what the parser read")
-
+class WriterRoundtripTest(unittest.TestCase,
+                          test_helpers.AssertParseWriteRoundtrip):
     def test_roundtrip_on_file(self):
         filename = os.path.join(
             os.path.dirname(__file__), 'data/GlyphsUnitTestSans.glyphs')

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -18,7 +18,9 @@ import unittest
 import math
 from textwrap import dedent
 from collections import OrderedDict
+import os
 
+import glyphsLib
 from glyphsLib import classes
 from glyphsLib.types import glyphs_datetime, point, rect
 
@@ -161,6 +163,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             .appVersion = 895;
             classes = (
             {
+            code = "";
             name = C1;
             }
             );
@@ -185,6 +188,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             );
             features = (
             {
+            code = "";
             name = F1;
             }
             );
@@ -489,6 +493,16 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             {
             automatic = 1;
             code = "e eacute egrave";
+            name = e;
+            }
+        """))
+
+        # When the code is an empty string, write an empty string
+        class_.code = ""
+        self.assertWrites(class_, dedent("""\
+            {
+            automatic = 1;
+            code = "";
             name = e;
             }
         """))
@@ -836,7 +850,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         self.assertWritesValue(
             node,
             '"10 30 CURVE SMOOTH {\\nname = \\"top-left corner\\";\\n\
-userData = {\\nrememberToDownloadARealRemindersApp = 1;\\n};\\n}"'
+rememberToDownloadARealRemindersApp = 1;\\n}"'
         )
 
     def test_write_guideline(self):
@@ -953,21 +967,21 @@ userData = {\\nrememberToDownloadARealRemindersApp = 1;\\n};\\n}"'
         """))
 
 
-# Might be impractical because of formatting (whitespace changes)?
-# Maybe it's OK because random glyphs files from github seem to be
-# formatted exactly like what this writer outputs
-# class WriterRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):
-#     def assertParseWriteRoundtrip(self, filename):
-#         with open(filename) as f:
-#             expected = f.readlines()
-#             font = glyphsLib.load(f)
-#         actual = test_helpers.write_to_lines(font)
-#         self.assertLinesEqual(
-#             expected, actual,
-#             "The writer should output exactly what the parser read")
+class WriterRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):
+    def assertParseWriteRoundtrip(self, filename):
+        with open(filename) as f:
+            expected = f.read().splitlines()
+            f.seek(0, 0)
+            font = glyphsLib.load(f)
+        actual = test_helpers.write_to_lines(font)
+        self.assertLinesEqual(
+            expected, actual,
+            "The writer should output exactly what the parser read")
 
-#     def test_roundtrip_on_file(self):
-#         self.assertParseWriteRoundtrip('data/GlyphsUnitTestSans.glyphs')
+    def test_roundtrip_on_file(self):
+        filename = os.path.join(
+            os.path.dirname(__file__), 'data/GlyphsUnitTestSans.glyphs')
+        self.assertParseWriteRoundtrip(filename)
 
 
 if __name__ == '__main__':

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -1,0 +1,71 @@
+# coding=UTF-8
+#
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import datetime
+from textwrap import dedent
+
+import glyphsLib
+from glyphsLib import classes
+
+import test_helpers
+
+class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
+    def assertWritten(self, glyphs_object, text):
+        """Assert that the given object, when given to the writer,
+        produces the given text.
+        """
+        expected = text.splitlines()
+        actual = test_helpers.write_to_lines(glyphs_object)
+        # print(expected)
+        # print(actual)
+        self.assertLinesEqual(
+            expected, actual,
+            "The writer has not produced the expected output")
+
+    def test_write_font_attributes(self):
+        font = classes.GSFont()
+        font.appVersion = 895
+        font.date = datetime.datetime(2017, 10, 3, 7, 35, 46, 897234)
+        font.familyName = 'MyFont'
+        self.assertWritten(font, dedent("""\
+            {
+            .appVersion = 895;
+            date = "2017-10-03 07:35:46.897234 +0000";
+            familyName = MyFont;
+            versionMajor = 1;
+            versionMinor = 0;
+            }
+        """))
+
+
+# Might be impractical because of formatting (whitespace changes)
+# class WriterRoundtripTest(unittest.TestCase, test_helpers.AssertLinesEqual):
+#     def assertParseWriteRoundtrip(self, filename):
+#         with open(filename) as f:
+#             expected = f.readlines()
+#             font = glyphsLib.load(f)
+#         actual = test_helpers.write_to_lines(font)
+#         self.assertLinesEqual(
+#             expected, actual,
+#             "The writer should output exactly what the parser read")
+
+#     def test_roundtrip_on_file(self):
+#         self.assertParseWriteRoundtrip('data/GlyphsUnitTestSans.glyphs')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -20,7 +20,7 @@ from textwrap import dedent
 from collections import OrderedDict
 
 from glyphsLib import classes
-from glyphsLib.types import glyphs_datetime, point
+from glyphsLib.types import glyphs_datetime, point, rect
 
 import test_helpers
 
@@ -913,7 +913,34 @@ userData = {\\nrememberToDownloadARealRemindersApp = 1;\\n};\\n}"'
 
         # FIXME: (jany) Add a test for target = "up"?
 
-    # def test_write_background_image
+    def test_write_background_image(self):
+        image = classes.GSBackgroundImage('/tmp/img.jpg')
+        # http://docu.glyphsapp.com/#gsbackgroundimage
+        # path: already set
+        # image: read-only, objective-c
+        image.crop = rect(point(0, 10), point(500, 510))
+        image.locked = True
+        image.alpha = 70
+        image.position = point(40, 90)
+        image.scale = (1.1, 1.2)
+        image.rotation = 0.3
+        # transform: Already set with scale/rotation
+        self.assertWrites(image, dedent("""\
+            {
+            alpha = 70;
+            crop = "{{0, 10}, {500, 510}}";
+            imagePath = "/tmp/img.jpg";
+            locked = 1;
+            transform = (
+            1.09998,
+            0.00576,
+            -0.00628,
+            1.19998,
+            40,
+            90
+            );
+            }
+        """))
 
 
 # Might be impractical because of formatting (whitespace changes)?

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -479,11 +479,11 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             "{\nname = fsType;\nvalue = (\n1,\n2\n);\n}")
 
     def test_write_class(self):
-        _class = classes.GSClass()
-        _class.name = "e"
-        _class.code = "e eacute egrave"
-        _class.automatic = True
-        self.assertWrites(_class, dedent("""\
+        class_ = classes.GSClass()
+        class_.name = "e"
+        class_.code = "e eacute egrave"
+        class_.automatic = True
+        self.assertWrites(class_, dedent("""\
             {
             automatic = 1;
             code = "e eacute egrave";

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -594,6 +594,127 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+    def test_write_layer(self):
+        layer = classes.GSLayer()
+        # http://docu.glyphsapp.com/#gslayer
+        # parent: not written
+        # name
+        layer.name = '{125, 100}'
+        # associatedMasterId
+        layer.associatedMasterId = 'M1'
+        # layerId
+        layer.layerId = 'L1'
+        # color
+        layer.color = 2  # brown
+        # colorObject: read-only, computed
+        # components
+        component = classes.GSComponent(glyph='glyphName')
+        layer.components.append(component)
+        # guides
+        guide = classes.GSGuideLine()
+        guide.name = 'xheight'
+        layer.guides.append(guide)
+        # annotations
+        annotation = classes.GSAnnotation()
+        # annotation.type = TEXT  # FIXME: (jany) this constant from the doc's examples is not defined
+        annotation.type = 'TEXT'
+        annotation.text = 'Fuck, this curve is ugly!'
+        layer.annotations.append(annotation)
+        # hints
+        hint = classes.GSHint()
+        hint.name = 'hintName'
+        layer.hints.append(hint)
+        # anchors
+        anchor = classes.GSAnchor()
+        anchor.name = 'top'
+        layer.anchors['top'] = anchor
+        # paths
+        path = classes.GSPath()
+        layer.paths.append(path)
+        # selection: read-only
+        # LSB, RSB, TSB, BSB: not written
+        # width
+        layer.width = 890.4
+        # leftMetricsKey
+        layer.leftMetricsKey = "A"
+        # rightMetricsKey
+        layer.rightMetricsKey = "A"
+        # widthMetricsKey
+        layer.widthMetricsKey = "A"
+        # bounds: read-only, computed
+        # selectionBounds: read-only, computed
+        # background
+        # FIXME: (jany) why not use a GSLayer like the official doc suggests?
+        background_layer = classes.GSBackgroundLayer()
+        layer.background = background_layer
+        # backgroundImage
+        image = classes.GSBackgroundImage('/path/to/file.jpg')
+        layer.backgroundImage = image
+        # bezierPath: read-only, objective-c
+        # openBezierPath: read-only, objective-c
+        # completeOpenBezierPath: read-only, objective-c
+        # isAligned
+        # FIXME: (jany) is this read-only?
+        #   is this computed from each component's alignment?
+        # layer.isAligned = False
+        # userData
+        layer.userData['rememberToMakeCoffe'] = True
+        # smartComponentPoleMapping
+        layer.smartComponentPoleMapping['crotchDepth'] = 2  # Top pole
+        layer.smartComponentPoleMapping['shoulderWidth'] = 1  # Bottom pole
+        self.assertWrites(layer, dedent("""\
+            {
+            anchors = (
+            {
+            name = top;
+            }
+            );
+            annotations = (
+            {
+            position = ;
+            text = "Fuck, this curve is ugly!";
+            type = TEXT;
+            }
+            );
+            associatedMasterId = M1;
+            background = {
+            };
+            backgroundImage = {
+            crop = "{{0, 0}, {0, 0}}";
+            imagePath = "/path/to/file.jpg";
+            };
+            color = 2;
+            components = (
+            {
+            name = glyphName;
+            }
+            );
+            guideLines = (
+            {
+            name = xheight;
+            }
+            );
+            hints = (
+            {
+            name = hintName;
+            }
+            );
+            layerId = L1;
+            leftMetricsKey = A;
+            widthMetricsKey = A;
+            rightMetricsKey = A;
+            name = "{125, 100}";
+            paths = (
+            {
+            }
+            );
+            userData = {
+            rememberToMakeCoffe = 1;
+            };
+            width = 890.4;
+            }
+        """))
+
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be
 # formatted exactly like what this writer outputs

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -629,6 +629,11 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+        # Write the script even when it's an empty string
+        glyph.script = ""
+        written = test_helpers.write_to_lines(glyph)
+        self.assertIn('script = "";', written)
+
     def test_write_layer(self):
         layer = classes.GSLayer()
         # http://docu.glyphsapp.com/#gslayer

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -662,9 +662,14 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         """))
 
         # Write the script even when it's an empty string
+        # Same for category and subCategory
         glyph.script = ""
+        glyph.category = ""
+        glyph.subCategory = ""
         written = test_helpers.write_to_lines(glyph)
         self.assertIn('script = "";', written)
+        self.assertIn('category = "";', written)
+        self.assertIn('subCategory = "";', written)
 
     def test_write_layer(self):
         layer = classes.GSLayer()

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -770,7 +770,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             {
             anchor = top;
             name = dieresis;
-            smartComponentValues = {
+            piece = {
             crotchDepth = -77;
             };
             transform = "{1.99925, 0.05482, -0.05482, 1.99925, 45.5, 250}";

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -493,14 +493,29 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
 
     def test_feature_prefix(self):
         fp = classes.GSFeaturePrefix()
-        fp.name = "sups"
-        fp.code = "    sub @standard by @sups;"
+        fp.name = "Languagesystems"
+        fp.code = "languagesystem DFLT dflt;"
         fp.automatic = True
         self.assertWrites(fp, dedent("""\
             {
             automatic = 1;
+            code = "languagesystem DFLT dflt;";
+            name = Languagesystems;
+            }
+        """))
+
+    def test_feature(self):
+        feature = classes.GSFeature()
+        feature.name = "sups"
+        feature.code = "    sub @standard by @sups;"
+        feature.automatic = True
+        feature.notes = "notes about sups"
+        self.assertWrites(feature, dedent("""\
+            {
+            automatic = 1;
             code = "    sub @standard by @sups;";
             name = sups;
+            notes = "notes about sups";
             }
         """))
 

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -773,6 +773,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
 
     def test_write_smart_component_axis(self):
         axis = classes.GSSmartComponentAxis()
+        # http://docu.glyphsapp.com/#gssmartcomponentaxis
         axis.name = "crotchDepth"
         axis.topValue = 0
         axis.bottomValue = -100
@@ -781,6 +782,29 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             {
             bottomValue = -100;
             name = crotchDepth;
+            }
+        """))
+
+    def test_write_path(self):
+        path = classes.GSPath()
+        # http://docu.glyphsapp.com/#gspath
+        # parent: not written
+        # nodes
+        node = classes.GSNode()
+        path.nodes.append(node)
+        # segments: computed, objective-c
+        # closed
+        path.closed = True
+        # direction: computed
+        # bounds: computed
+        # selected: not written
+        # bezierPath: computed
+        self.assertWrites(path, dedent("""\
+            {
+            closed = 1;
+            nodes = (
+            "0 0 LINE"
+            );
             }
         """))
 

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -15,11 +15,9 @@
 # limitations under the License.
 
 import unittest
-import datetime
 from textwrap import dedent
 from collections import OrderedDict
 
-import glyphsLib
 from glyphsLib import classes
 from glyphsLib.types import glyphs_datetime
 
@@ -33,8 +31,6 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         """
         expected = text.splitlines()
         actual = test_helpers.write_to_lines(glyphs_object)
-        # print(expected)
-        # print(actual)
         self.assertLinesEqual(
             expected, actual,
             "The writer has not produced the expected output")
@@ -122,7 +118,6 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # grid
         font.grid = 35
         # gridSubDivisions
-        # FIXME: (jany) In this library it is called "gridSubDivision" (no s)
         font.gridSubDivisions = 5
         # gridLength
         font.gridLength = 2
@@ -206,6 +201,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             );
             grid = 35;
             gridLength = 2;
+            gridSubDivision = 5;
             instances = (
             {
             name = MuchBold;

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -238,7 +238,9 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # id
         master.id = "MASTER-ID"
         # name
-        master.name = "Hairline Megawide"
+        # Cannot set the `name` attribute directly
+        # master.name = "Hairline Megawide"
+        master.customParameters['Master Name'] = "Hairline Megawide"
         # weight
         master.weight = "Thin"
         # width

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -771,6 +771,18 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+    def test_write_smart_component_axis(self):
+        axis = classes.GSSmartComponentAxis()
+        axis.name = "crotchDepth"
+        axis.topValue = 0
+        axis.bottomValue = -100
+        # FIXME: (jany) keys that have value 0 are not written?
+        self.assertWrites(axis, dedent("""\
+            {
+            bottomValue = -100;
+            name = crotchDepth;
+            }
+        """))
 
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -125,9 +125,6 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # gridLength
         font.gridLength = 2
         # keyboardIncrement
-        # FIXME: (jany) Not handled by this library, maybe because it's a
-        #   UI feature from Glyphs.app. It should be handled though, so that
-        #   designers who use the export/import macros don't lose their settings?
         font.keyboardIncrement = 1.2
         # disablesNiceNames
         font.disablesNiceNames = True
@@ -220,6 +217,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             };
             };
             };
+            keyboardIncrement = 1.2;
             manufacturer = Manu;
             manufacturerURL = manu.com;
             unitsPerEm = 2000;

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -844,6 +844,24 @@ userData = {\\nrememberToDownloadARealRemindersApp = 1;\\n};\\n}"'
             }
         """))
 
+    def test_write_annotation(self):
+        annotation = classes.GSAnnotation()
+        # http://docu.glyphsapp.com/#gsannotation
+        annotation.position = point(12, 34)
+        annotation.type = classes.GSAnnotation.TEXT
+        annotation.text = "Look here"
+        annotation.angle = 123.5
+        annotation.width = 135
+        self.assertWrites(annotation, dedent("""\
+            {
+            angle = 123.5;
+            position = "{12, 34}";
+            text = "Look here";
+            type = Text;
+            width = 135;
+            }
+        """))
+
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be
 # formatted exactly like what this writer outputs

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -192,10 +192,16 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             );
             fontMaster = (
             {
+            ascender = 800;
+            capHeight = 700;
             id = M1;
+            xHeight = 500;
             },
             {
+            ascender = 800;
+            capHeight = 700;
             id = M2;
+            xHeight = 500;
             }
             );
             glyphs = (

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -103,9 +103,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # familyName
         font.familyName = "Sans Rien"
         # upm
-        # FIXME: (jany) In this library it is called "unitsPerEm"
-        # font.upm = 2000
-        font.unitsPerEm = 2000
+        font.upm = 2000
         # note
         font.note = "Was bored, made this"
         # kerning
@@ -138,11 +136,8 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # customParameters
         font.customParameters['ascender'] = 300
         # selection
-        # FIXME: (jany) Not handled by this library.
-        #   Not sure that it makes sense to handle it, because the selection
-        #   sounds like a very impermanent thing that will not be expected to
-        #   be restored after an export/import to UFO.
-        #   Maybe it would still be nice to have? TODO: ask a designer?
+        # FIXME: (jany) Not writable here: instead, check that individual
+        #   glyphs store their "selected" status correctly
         # font.selection = ?
         # selectedLayers
         # FIXME: (jany) Same as `selection`
@@ -225,6 +220,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             };
             manufacturer = Manu;
             manufacturerURL = manu.com;
+            unitsPerEm = 2000;
             userData = {
             a = test;
             b = (

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -796,6 +796,11 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+        # Don't write a blank layer name
+        layer.name = ""
+        written = test_helpers.write_to_lines(layer)
+        self.assertNotIn('name = "";', written)
+
     def test_write_anchor(self):
         anchor = classes.GSAnchor('top', point(23, 45.5))
         self.assertWrites(anchor, dedent("""\

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -966,22 +966,19 @@ rememberToDownloadARealRemindersApp = 1;\\n}"'
         path1.nodes.append(node1)
         hint.originNode = node1
 
-        # FIXME: (jany) implement the same official Python API as for `origin`
-        # path1.nodes.append(node2)
-        # node2 = classes.GSNode(point(200, 200))
-        # hint.targetNode = node2
-        hint.target = point(0, 1)
+        node2 = classes.GSNode(point(200, 200))
+        path1.nodes.append(node2)
+        hint.targetNode = node2
 
-        # node3 = classes.GSNode(point(300, 300))
-        # path1.nodes.append(node3)
-        # hint.otherNode1 = node3
-        hint.other1 = point(0, 2)
+        node3 = classes.GSNode(point(300, 300))
+        path1.nodes.append(node3)
+        hint.otherNode1 = node3
 
-        # path2 = classes.GSPath()
-        # node4 = classes.GSNode(point(400, 400))
-        # path2.nodes.append(node4)
-        # hint.otherNode2 = node4
-        hint.other2 = point(1, 0)
+        path2 = classes.GSPath()
+        layer.paths.append(path2)
+        node4 = classes.GSNode(point(400, 400))
+        path2.nodes.append(node4)
+        hint.otherNode2 = node4
 
         hint.type = classes.CORNER
         hint.options = classes.TTROUND | classes.TRIPLE

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -592,8 +592,22 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # mastersCompatible: not stored
         # userData
         glyph.userData['rememberToMakeCoffe'] = True
+        # Check that empty collections are written
+        glyph.userData['com.someoneelse.coolsoftware.customdata'] = [
+            OrderedDict([
+                ('zero', 0),
+                ('emptyList', []),
+                ('emptyDict', {}),
+                ('emptyString', ""),
+            ]),
+            [],
+            {},
+            "",
+            "hey",
+            0,
+            1,
+        ]
         # smartComponentAxes
-        # TODO: GSSmartComponentAxis
         axis = classes.GSSmartComponentAxis()
         axis.name = "crotchDepth"
         glyph.smartComponentAxes.append(axis)
@@ -617,6 +631,24 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             category = Letter;
             subCategory = Uppercase;
             userData = {
+            com.someoneelse.coolsoftware.customdata = (
+            {
+            zero = 0;
+            emptyList = (
+            );
+            emptyDict = {
+            };
+            emptyString = "";
+            },
+            (
+            ),
+            {
+            },
+            "",
+            hey,
+            0,
+            1
+            );
             rememberToMakeCoffe = 1;
             };
             partsSettings = (

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -855,13 +855,20 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # name
         node.name = "top-left corner"
         # userData
-        # FIXME: (jany) Not sure about the userData part
         node.userData["rememberToDownloadARealRemindersApp"] = True
         self.assertWritesValue(
             node,
             '"10 30 CURVE SMOOTH {\\nname = \\"top-left corner\\";\\n\
 rememberToDownloadARealRemindersApp = 1;\\n}"'
         )
+
+        # Write floating point coordinates
+        node = classes.GSNode(point(499.99, 512.01), classes.GSNode.OFFCURVE)
+        self.assertWritesValue(
+            node,
+            '"499.99 512.01 OFFCURVE"'
+        )
+
 
     def test_write_guideline(self):
         line = classes.GSGuideLine()

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -235,6 +235,11 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             }
         """))
 
+        # Don't write the keyboardIncrement if it's None
+        font.keyboardIncrement = None
+        written = test_helpers.write_to_lines(font)
+        self.assertFalse(any("keyboardIncrement" in line for line in written))
+
     def test_write_font_master_attributes(self):
         """Test the writer on all GSFontMaster attributes"""
         master = classes.GSFontMaster()

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -821,13 +821,28 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         # name
         node.name = "top-left corner"
         # userData
-        # FIXME: (jany) The user data is missing!
+        # FIXME: (jany) Not sure about the userData part
         node.userData["rememberToDownloadARealRemindersApp"] = True
         self.assertWritesValue(
             node,
             '"10 30 CURVE SMOOTH {\\nname = \\"top-left corner\\";\\n\
 userData = {\\nrememberToDownloadARealRemindersApp = 1;\\n};\\n}"'
         )
+
+    def test_write_guideline(self):
+        line = classes.GSGuideLine()
+        # http://docu.glyphsapp.com/#GSGuideLine
+        line.position = point(56, 45)
+        line.angle = 11.0
+        line.name = "italic angle"
+        # selected: not written
+        self.assertWrites(line, dedent("""\
+            {
+            angle = 11;
+            name = "italic angle";
+            position = "{56, 45}";
+            }
+        """))
 
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -848,7 +848,7 @@ userData = {\\nrememberToDownloadARealRemindersApp = 1;\\n};\\n}"'
         annotation = classes.GSAnnotation()
         # http://docu.glyphsapp.com/#gsannotation
         annotation.position = point(12, 34)
-        annotation.type = classes.GSAnnotation.TEXT
+        annotation.type = classes.TEXT
         annotation.text = "Look here"
         annotation.angle = 123.5
         annotation.width = 135
@@ -857,10 +857,64 @@ userData = {\\nrememberToDownloadARealRemindersApp = 1;\\n};\\n}"'
             angle = 123.5;
             position = "{12, 34}";
             text = "Look here";
-            type = Text;
+            type = 1;
             width = 135;
             }
         """))
+
+    def test_write_hint(self):
+        hint = classes.GSHint()
+        # http://docu.glyphsapp.com/#gshint
+        # FIXME: (jany) understand how hints are stored
+        layer = classes.GSLayer()
+        path1 = classes.GSPath()
+        layer.paths.append(path1)
+        node1 = classes.GSNode(point(100, 100))
+        path1.nodes.append(node1)
+        hint.originNode = node1
+
+        # FIXME: (jany) implement the same official Python API as for `origin`
+        # path1.nodes.append(node2)
+        # node2 = classes.GSNode(point(200, 200))
+        # hint.targetNode = node2
+        hint.target = point(0, 1)
+
+        # node3 = classes.GSNode(point(300, 300))
+        # path1.nodes.append(node3)
+        # hint.otherNode1 = node3
+        hint.other1 = point(0, 2)
+
+        # path2 = classes.GSPath()
+        # node4 = classes.GSNode(point(400, 400))
+        # path2.nodes.append(node4)
+        # hint.otherNode2 = node4
+        hint.other2 = point(1, 0)
+
+        hint.type = classes.CORNER
+        hint.options = classes.TTROUND | classes.TRIPLE
+        hint.horizontal = True
+        # selected: not written
+        hint.name = "My favourite hint"
+        self.assertWrites(hint, dedent("""\
+            {
+            horizontal = 1;
+            origin = "{0, 0}";
+            target = "{0, 1}";
+            other1 = "{0, 2}";
+            other2 = "{1, 0}";
+            type = 16;
+            name = "My favourite hint";
+            options = 128;
+            }
+        """))
+
+        # FIXME: (jany) What about the undocumented scale & stem?
+        #   -> Add a test for that
+
+        # FIXME: (jany) Add a test for target = "up"?
+
+    # def test_write_background_image
+
 
 # Might be impractical because of formatting (whitespace changes)?
 # Maybe it's OK because random glyphs files from github seem to be

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@ envlist = py27, py36
 [testenv]
 deps =
 	pytest
+	coverage
 	mock>=2.0.0
 	-rrequirements.txt
 commands =
-	pytest {posargs}
+	coverage erase
+	coverage run --source glyphsLib --omit "*tests/*" --branch -m pytest {posargs}
+	coverage report


### PR DESCRIPTION
@moyogo 

This is a work in progress to have full round-trip between .glyphs files and UFO3 + designspace.

Plan:

1. Add tests for the writer (GS* classes -> .glyphs file)
    * Document (and fix?) small inconsistencies between the GS* classes and the Glyphs Python API documentation at https://docu.glyphsapp.com/
    * Add tests for the .glyphs -> GS classes -> .glyphs round-trip (e.g. https://gist.github.com/anthrotype/3f4c9b3e04c22ddcfda196b970de8549)
2. Merge classtree + the new tests in master

In another MR:
1. Test the round-trip using the writer:
```
 Test input = GSFont ------------------> designspace+UFO  ------------------> GSFont      
                |     builder/ufo.py   MutatorMath+defcon   builder/glyphs.py   |         
                |                                                (TODO)         |         
                |writer.py                                                      |writer.py
                |                                                               |         
                v                                                               v         
             .glyphs    <------------------------------------------------>   .glyphs      
                                 Test result = SHOULD BE THE SAME                                      
```

2. Implement all of `builder/glyphs.py` (UFO -> GSFont, the opposite of `builder/ufo.py`)