### PR TITLE
Handle input files that use production names instead of Glyphs names

### DIFF
--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -31,7 +31,18 @@ Glyph = namedtuple("Glyph", "name,production_name,unicode,category,subCategory")
 
 
 def get_glyph(name, data=glyphdata_generated):
-    prodname = data.PRODUCTION_NAMES.get(name, name)
+    prodname = data.PRODUCTION_NAMES.get(name)
+    # Some Glyphs files use production names (instead of Glyphs names).
+    # We catch this here, so that we can return the same properties as if
+    # the Glyphs file had been following the Glyphs naming conventions.
+    # https://github.com/googlei18n/glyphsLib/issues/232
+    if prodname is None:
+        rev_prodname = data.PRODUCTION_NAMES_REVERSED.get(name)
+        if rev_prodname is not None:
+            prodname = name
+            name = rev_prodname
+    if prodname is None:
+        prodname = name
     unistr = data.IRREGULAR_UNICODE_STRINGS.get(name)
     if unistr is None:
         unistr = agl.toUnicode(prodname)

--- a/Lib/glyphsLib/glyphdata_generated.py
+++ b/Lib/glyphsLib/glyphdata_generated.py
@@ -26542,6 +26542,10 @@ PRODUCTION_NAMES = {
 	"zzyx-yi":"uniA2E8",
 }
 
+PRODUCTION_NAMES_REVERSED = {
+	agl: g for g, agl in PRODUCTION_NAMES.items()
+}
+
 # Glyphs for which Glyphs.app has a different Unicode string
 # than the string we would generate from the production name.
 IRREGULAR_UNICODE_STRINGS = {

--- a/MetaTools/generate_glyphdata.py
+++ b/MetaTools/generate_glyphdata.py
@@ -201,6 +201,10 @@ def generate_python_source(data, out):
         out.write('\t"%s":"%s",\n' % (key, value))
     out.write("}\n\n")
 
+    out.write("PRODUCTION_NAMES_REVERSED = {\n"
+              "\tagl: g for g, agl in PRODUCTION_NAMES.items()\n"
+              "}\n\n")
+
     out.write(
         "# Glyphs for which Glyphs.app has a different Unicode string\n"
         "# than the string we would generate from the production name.\n")

--- a/tests/glyphdata_test.py
+++ b/tests/glyphdata_test.py
@@ -62,6 +62,16 @@ class GlyphDataTest(unittest.TestCase):
         self.assertEqual(cat("o_f_f_i.foo"), ("Letter", "Ligature"))
         self.assertEqual(cat("ain_alefMaksura-ar.fina"), ("Letter", "Ligature"))
 
+    def test_bug232(self):
+        # https://github.com/googlei18n/glyphsLib/issues/232
+        u, g = get_glyph("uni07F0"), get_glyph("longlowtonecomb-nko")
+        self.assertEqual((u.category, g.category), ("Mark", "Mark"))
+        self.assertEqual((u.subCategory, g.subCategory),
+                         ("Nonspacing", "Nonspacing"))
+        self.assertEqual((u.production_name, g.production_name),
+                         ("uni07F0", "uni07F0"))
+        self.assertEqual((u.unicode, g.unicode), ("\u07F0", "\u07F0"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/googlei18n/glyphsLib/issues/232