### PR TITLE
Adding control over anchor propagation

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -59,7 +59,7 @@ def loads(s):
 
 
 def load_to_ufos(file_or_path, include_instances=False, family_name=None,
-                 debug=False):
+                 propagate_anchors=True, debug=False):
     """Load an unpacked .glyphs object to UFO objects."""
 
     if hasattr(file_or_path, 'read'):
@@ -69,11 +69,11 @@ def load_to_ufos(file_or_path, include_instances=False, family_name=None,
             font = load(ifile)
     logger.info('Loading to UFOs')
     return to_ufos(font, include_instances=include_instances,
-                   family_name=family_name, debug=debug)
+                   family_name=family_name, propagate_anchors=propagate_anchors, debug=debug)
 
 
 def build_masters(filename, master_dir, designspace_instance_dir=None,
-                  family_name=None):
+                  family_name=None, propagate_anchors=True):
     """Write and return UFOs from the masters defined in a .glyphs file.
 
     Args:
@@ -90,7 +90,7 @@ def build_masters(filename, master_dir, designspace_instance_dir=None,
     """
 
     ufos, instance_data = load_to_ufos(
-        filename, include_instances=True, family_name=family_name)
+        filename, include_instances=True, family_name=family_name, propagate_anchors=propagate_anchors)
     if designspace_instance_dir is not None:
         designspace_path, instance_data = build_designspace(
             ufos, master_dir, designspace_instance_dir, instance_data)
@@ -102,7 +102,7 @@ def build_masters(filename, master_dir, designspace_instance_dir=None,
 
 
 def build_instances(filename, master_dir, instance_dir, family_name=None,
-                    round_geometry=True):
+                    propagate_anchors=True, round_geometry=True):
     """Write and return UFOs from the instances defined in a .glyphs file.
 
     Args:
@@ -113,7 +113,7 @@ def build_instances(filename, master_dir, instance_dir, family_name=None,
     """
 
     master_ufos, instance_data = load_to_ufos(
-        filename, include_instances=True, family_name=family_name)
+        filename, include_instances=True, family_name=family_name, propagate_anchors=propagate_anchors)
     instance_ufos = interpolate(
         master_ufos, master_dir, instance_dir, instance_data,
         round_geometry=round_geometry)

--- a/Lib/glyphsLib/builder.py
+++ b/Lib/glyphsLib/builder.py
@@ -95,7 +95,7 @@ CODEPAGE_RANGES = {
 }
 
 
-def to_ufos(font, include_instances=False, family_name=None, debug=False):
+def to_ufos(font, include_instances=False, family_name=None, propagate_anchors=True, debug=False):
     """Take .glyphs file data and load it into UFOs.
 
     Takes in data as a dictionary structured according to
@@ -194,7 +194,8 @@ def to_ufos(font, include_instances=False, family_name=None, debug=False):
 
     for ufo in ufos.values():
         ufo.lib[glyphOrder_key] = glyph_order
-        propagate_font_anchors(ufo)
+        if propagate_anchors:
+            propagate_font_anchors(ufo)
         add_features_to_ufo(ufo, feature_prefixes, classes, features)
         add_groups_to_ufo(ufo, kerning_groups)
 


### PR DESCRIPTION
Adding an argument to to_ufos() that gives control over whether propagate_font_anchors() is run. Also enables that argument to be used by load_to_ufos(), build_masters(), build_instances(). The default remains True - that propagation is done unless specifically turned off.