### PR TITLE
better handle bytes/unicode and clean up Writer api

### DIFF
--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -54,7 +54,7 @@ class Parser(object):
         return result
 
     def parse_into_object(self, res, text):
-        """Do the parsing."""
+        """Parse data into an existing GSFont instance."""
 
         text = tounicode(text, encoding='utf-8')
 
@@ -229,7 +229,8 @@ def load(fp):
 
 
 def loads(s):
-    """Read a .glyphs file from a bytes object.
+    """Read a .glyphs file from a (unicode) str object, or from
+    a UTF-8 encoded bytes object.
     Return a GSFont object.
     """
     p = Parser(current_type=glyphsLib.classes.GSFont)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -21,16 +21,16 @@ from textwrap import dedent
 import glyphsLib
 from glyphsLib.builder import to_glyphs, to_ufos
 from glyphsLib.writer import Writer
-from fontTools.misc.py23 import StringIO
+from fontTools.misc.py23 import UnicodeIO
 
 
 def write_to_lines(glyphs_object):
     """
-    Use the Writer to write the given object to a StringIO.
+    Use the Writer to write the given object to a UnicodeIO.
     Return an array of lines ready for diffing.
     """
-    string = StringIO()
-    writer = Writer(fp=string)
+    string = UnicodeIO()
+    writer = Writer(string)
     writer.write(glyphs_object)
     return string.getvalue().splitlines()
 


### PR DESCRIPTION
I took the stuff from https://github.com/googlei18n/glyphsLib/pull/213 that was worth porting over to the new classtree interface.

- make Writer only accept a single argument, the file object
- don't auto-close file, leave that to user
- handle both file objects open as binary or text
- dumps return a unicode str (like py3 json)
- Use UnicodeIO instead of StringIO to explicitly write to a unicode stream in both py2 and py3