### PR TITLE
Make glyphs_datetime parse 12hr format correctly

### DIFF
--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -225,7 +225,14 @@ class glyphs_datetime(baseType):
         # parse timezone ourselves, since %z is not always supported
         # see: http://bugs.python.org/issue6641
         string, tz = src.rsplit(' ', 1)
-        datetime_obj = datetime.datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
+        if 'AM' in string or 'PM' in string:
+            datetime_obj = datetime.datetime.strptime(
+                string, '%Y-%m-%d %I:%M:%S %p'
+            )
+        else:
+            datetime_obj = datetime.datetime.strptime(
+                string, '%Y-%m-%d %H:%M:%S'
+            )
         offset = datetime.timedelta(
             hours=int(tz[:3]), minutes=int(tz[0] + tz[3:]))
         return datetime_obj + offset

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -1,0 +1,44 @@
+# coding=UTF-8
+#
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (
+    print_function, division, absolute_import, unicode_literals)
+
+import datetime
+import unittest
+
+from glyphsLib.types import glyphs_datetime
+
+
+class GlyphsDateTimeTest(unittest.TestCase):
+
+    def test_parsing_24hr_format(self):
+        """Assert glyphs_datetime can parse 24 hour time formats"""
+        string_24hrs = '2017-01-01 17:30:30 +0000'
+        test_time = glyphs_datetime()
+        self.assertEqual(test_time.read(string_24hrs),
+                         datetime.datetime(2017, 1, 1, 17, 30, 30))
+
+    def test_parsing_12hr_format(self):
+        """Assert glyphs_datetime can parse 12 hour time format"""
+        string_12hrs = '2017-01-01 5:30:30 PM +0000'
+        test_time = glyphs_datetime()
+        self.assertEqual(test_time.read(string_12hrs),
+                         datetime.datetime(2017, 1, 1, 17, 30, 30))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I've been trying to batch a collection of .glyphs files using glyphsLib. whilst using it on an NDA project, it throws the following traceback

```
Traceback (most recent call last):
  File "generate_variable_fonts.py", line 238, in <module>
    main(sys.argv[1], sys.argv[2])
  File "generate_variable_fonts.py", line 216, in main
    mm_families_paths = find_mm_compatible_glyphs_files(path)
  File "generate_variable_fonts.py", line 63, in find_mm_compatible_glyphs_files
    glyphs_source = glyphsLib.load(glyphs_file)
  File "/Users/marc/Documents/googlefonts/variable_fonts/env/lib/python2.7/site-packages/glyphsLib/parser.py", line 228, in load
    return loads(fp.read())
  File "/Users/marc/Documents/googlefonts/variable_fonts/env/lib/python2.7/site-packages/glyphsLib/parser.py", line 238, in loads
    data = p.parse(s)
  File "/Users/marc/Documents/googlefonts/variable_fonts/env/lib/python2.7/site-packages/glyphsLib/parser.py", line 51, in parse
    result, i = self._parse(text, 0)
  File "/Users/marc/Documents/googlefonts/variable_fonts/env/lib/python2.7/site-packages/glyphsLib/parser.py", line 95, in _parse
    return self._parse_dict(text, i)
  File "/Users/marc/Documents/googlefonts/variable_fonts/env/lib/python2.7/site-packages/glyphsLib/parser.py", line 137, in _parse_dict
    i = self._parse_dict_into_object(res, text, i)
  File "/Users/marc/Documents/googlefonts/variable_fonts/env/lib/python2.7/site-packages/glyphsLib/parser.py", line 152, in _parse_dict_into_object
    result = self._parse(text, i)
  File "/Users/marc/Documents/googlefonts/variable_fonts/env/lib/python2.7/site-packages/glyphsLib/parser.py", line 109, in _parse
    value = reader.read(value)
  File "/Users/marc/Documents/googlefonts/variable_fonts/env/lib/python2.7/site-packages/glyphsLib/types.py", line 228, in read
    datetime_obj = datetime.datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/_strptime.py", line 328, in _strptime
    data_string[found.end():])
ValueError: unconverted data remains:  AM
```

This Glyphs file is a few years old which leads me to suspect that in Glyphs V1 the time format was 12hrs, instead of the current 24hr format. If I look at the .glyphs file the date is `date = "2016-06-05 3:23:08 AM +0000";`

I couldn't find a suitable place to include the tests for this so I have created a new module.

When I save the .glyphs file in Glyphs V2.000 the problem disappears because the date gets converted to 24hr time, `date = "2016-06-05 03:23:08 +0000";`


If you don't support Glyphs V1, please close this pr.

Also, thank you for the wonderful Lib. It has made my life much easier.