### PR TITLE
Set hhea caretSlopeRise and caretSlopeRun based on italicAngle value

### DIFF
--- a/Lib/glyphsLib/builder/font.py
+++ b/Lib/glyphsLib/builder/font.py
@@ -17,6 +17,7 @@ from __future__ import (print_function, division, absolute_import,
 
 from collections import deque, OrderedDict
 import logging
+import math
 
 from .common import to_ufo_time
 from .constants import GLYPHS_PREFIX
@@ -80,6 +81,8 @@ def to_ufo_font_attributes(self, family_name):
             ufo.info.postscriptStemSnapV = vertical_stems
         if italic_angle:
             ufo.info.italicAngle = italic_angle
+            ufo.info.openTypeHheaCaretSlopeRise = 1000
+            ufo.info.openTypeHheaCaretSlopeRun = int(math.tan(math.radians(-italic_angle)) * 1000)
 
         width = master.width
         weight = master.weight


### PR DESCRIPTION
It appears that Glyphs (or makeotf?) calculates `caretSlopeRise` and `caretSlopeRun` from the italicAngle, but glyphsLib doesn't do this anywhere. ufo2ft checks for `openTypeHheaCaretSlopeRise` and `openTypeHheaCaretSlopeRun` so all we need to do for the default is to add these to the ufo. 
I tested on a few files and this gives me the same hhea values that are generated when exported from Glyphs. 
@schriftgestalt does this look correct to you? 
