### PR TITLE
Read colors and set UFO keys for Glyphs ColorIndex and public.markColor

### DIFF
--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -14,6 +14,8 @@
 
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
+import logging
+logger = logging.getLogger(__name__)
 
 import glyphsLib
 from .common import to_ufo_time
@@ -35,9 +37,21 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph_data):
     if last_change is not None:
         ufo_glyph.lib[GLYPHLIB_PREFIX + 'lastChange'] = to_ufo_time(last_change)
     color_index = glyph_data.color
-    if color_index is not None and color_index >= 0:
+    if color_index is not None:
         ufo_glyph.lib[GLYPHLIB_PREFIX + 'ColorIndex'] = color_index
-        ufo_glyph.lib[PUBLIC_PREFIX + 'markColor'] = GLYPHS_COLORS[color_index]
+        color_tuple = None
+        if isinstance(color_index, list):
+            if not all(i in range(0, 256) for i in color_index):
+                logger.warn('Invalid color tuple {} for glyph {}. '
+                            'Values must be in range 0-255'.format(color_index, glyph_data.name))
+            else:
+                color_tuple = ','.join('{0:.4f}'.format(i/255) if i in range(1, 255) else str(i//255) for i in color_index)
+        elif isinstance(color_index, int) and color_index in range(len(GLYPHS_COLORS)):
+            color_tuple = GLYPHS_COLORS[color_index]
+        else:
+            logger.warn('Invalid color index {} for {}'.format(color_index, glyph_data.name))
+        if color_tuple is not None:
+            ufo_glyph.lib[PUBLIC_PREFIX + 'markColor'] = color_tuple
     export = glyph_data.export
     if not export:
         ufo_glyph.lib[GLYPHLIB_PREFIX + 'Export'] = export

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -1131,5 +1131,40 @@ class DrawPathsTest(unittest.TestCase):
         self.assertEqual(first_segment_type, 'qcurve')
 
 
+class GlyphPropertiesTest(unittest.TestCase):
+
+    def test_glyph_color(self):
+        font = generate_minimal_font()
+        glyph = GSGlyph(name='a')
+        glyph2 = GSGlyph(name='b')
+        glyph3 = GSGlyph(name='c')
+        glyph4 = GSGlyph(name='d')
+        glyph.color = [244, 0, 138, 1]
+        glyph2.color = 3
+        glyph3.color = 88
+        glyph4.color = [800, 0, 138, 1]
+        font.glyphs.append(glyph)
+        font.glyphs.append(glyph2)
+        font.glyphs.append(glyph3)
+        font.glyphs.append(glyph4)
+        layer = GSLayer()
+        layer2 = GSLayer()
+        layer3 = GSLayer()
+        layer4 = GSLayer()
+        layer.layerId = font.masters[0].id
+        layer2.layerId = font.masters[0].id
+        layer3.layerId = font.masters[0].id
+        layer4.layerId = font.masters[0].id
+        glyph.layers.append(layer)
+        glyph2.layers.append(layer2)
+        glyph3.layers.append(layer3)
+        glyph4.layers.append(layer4)
+        ufo = to_ufos(font)[0]
+        self.assertEqual(ufo['a'].lib.get('public.markColor'), '0.9569,0,0.5412,0.0039')
+        self.assertEqual(ufo['b'].lib.get('public.markColor'), '0.97,1,0,1')
+        self.assertEqual(ufo['c'].lib.get('public.markColor'), None)
+        self.assertEqual(ufo['d'].lib.get('public.markColor'), None)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As mentioned here: https://github.com/googlei18n/glyphsLib/issues/116

With colors coming from outside Glyphs we were failing on `GLYPHS_COLORS[color_index]` when color_index wasn't in GLYPHS_COLORS. 
Here we should check for a tuple or a Glyphs color index and set the keys accordingly. Using the FontLab export script to make a Glyphs file results in tuples like (235,0,255,1), but the UFO spec requires integer or floats between 0 and 1 (http://unifiedfontobject.org/versions/ufo3/conventions/#colors). So check here to make sure we get what we expect. 

I'm not sure about how many decimal places we care about so put 4 for now.