### PR TITLE
Add name setter so Glyphs 2.5b "name" property in fontMaster doesn't conflict

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -399,7 +399,7 @@ class FontFontMasterProxy(Proxy):
             raise(KeyError)
 
     def __setitem__(self, Key, FontMaster):
-        FontMaster.parent = self._owner
+        FontMaster.font = self._owner
         if type(Key) is int:
             OldFontMaster = self.__getitem__(Key)
             if Key < 0:
@@ -414,7 +414,6 @@ class FontFontMasterProxy(Proxy):
         else:
             raise(KeyError)
 
-
     def __delitem__(self, Key):
         if type(Key) is int:
             if Key < 0:
@@ -428,7 +427,7 @@ class FontFontMasterProxy(Proxy):
         return self._owner._masters
 
     def append(self, FontMaster):
-        FontMaster.parent = self._owner
+        FontMaster.font = self._owner
         FontMaster.id = str(uuid.uuid4()).upper()
         self._owner._masters.append(FontMaster)
 
@@ -438,7 +437,6 @@ class FontFontMasterProxy(Proxy):
                 newLayer = GSLayer()
                 glyph._setupLayer(newLayer, FontMaster.id)
                 glyph.layers.append(newLayer)
-
 
     def remove(self, FontMaster):
 
@@ -451,7 +449,7 @@ class FontFontMasterProxy(Proxy):
         self._owner._masters.remove(FontMaster)
 
     def insert(self, Index, FontMaster):
-        FontMaster.parent = self._owner
+        FontMaster.font = self._owner
         self._owner._masters.insert(Index, FontMaster)
 
     def extend(self, FontMasters):
@@ -463,7 +461,7 @@ class FontFontMasterProxy(Proxy):
             values = list(values)
         self._owner._masters = values
         for m in self._owner._masters:
-            m.parent = self._owner
+            m.font = self._owner
 
 
 class FontGlyphsProxy(Proxy):
@@ -1157,10 +1155,10 @@ class GSFontMaster(GSBase):
         "descender": float,
         "guideLines": GSGuideLine,
         "horizontalStems": int,
+        "iconName": str,
         "id": str,
         "italicAngle": float,
         "name": str,
-        "iconName": str,
         "userData": dict,
         "verticalStems": int,
         "visible": bool,
@@ -1200,10 +1198,10 @@ class GSFontMaster(GSBase):
         "descender",
         "guideLines",
         "horizontalStems",
+        "iconName",
         "id",
         "italicAngle",
         "name",
-        "iconName",
         "userData",
         "verticalStems",
         "visible",
@@ -1215,8 +1213,8 @@ class GSFontMaster(GSBase):
     )
 
     def __init__(self):
-        self._font = None
         super(GSFontMaster, self).__init__()
+        self._font = None
         self._name = None
         self._customParameters = []
         self._weight = "Regular"
@@ -1240,9 +1238,9 @@ class GSFontMaster(GSBase):
             # Always write those values
             return True
         if key == "name":
-            if self.font and int(self.font.appVersion) >= 1075:
-                return True
-            return False
+            if getattr(self, key) == "Regular":
+                return False
+            return True
         return super(GSFontMaster, self).shouldWriteValueForKey(key)
 
     @property
@@ -1275,10 +1273,7 @@ class GSFontMaster(GSBase):
 
     @name.setter
     def name(self, value):
-        if self.font and int(self.font.appVersion) >= 1075:
-            self._name = value
-        else:
-            return
+        self._name = value
 
     customParameters = property(
         lambda self: CustomParametersProxy(self),
@@ -2771,9 +2766,8 @@ class GSFont(GSBase):
                 logger.info('Parsing .glyphs file into %r', self)
                 p.parse_into_object(self, fp.read())
             self.filepath = path
-
-        for master in self.masters:
-            master.font = self
+            for master in self.masters:
+                master.font = self
 
     def __repr__(self):
         return "<%s \"%s\">" % (self.__class__.__name__, self.familyName)

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1214,7 +1214,7 @@ class GSFontMaster(GSBase):
 
     def __init__(self):
         super(GSFontMaster, self).__init__()
-        self._font = None
+        self.font = None
         self._name = None
         self._customParameters = []
         self._weight = "Regular"
@@ -1242,14 +1242,6 @@ class GSFontMaster(GSBase):
                 return False
             return True
         return super(GSFontMaster, self).shouldWriteValueForKey(key)
-
-    @property
-    def font(self):
-        return self._font
-
-    @font.setter
-    def font(self, value):
-        self._font = value
 
     @property
     def name(self):

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -376,7 +376,8 @@ def encode_dict_as_string_for_gsnode(value):
     encoded such that it can be included in the string representation
     of a GSNode."""
     value = value.replace('"', '\\"')
-    return value.replace("\n", "\\n")
+    value = value.replace('\n', '')
+    return value.replace(";", ";\\n", value.count(';') - 1)
 
 
 # FIXME: (jany) This is not a correct reverse function, if

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -429,11 +429,6 @@ class GSFontFromFileTest(GSObjectsTestCase):
         self.assertEqual(amount, len(list(font.customParameters)))
         del font.customParameters['trademark']
 
-    # def test_font_master_is_name_not_writable(self):
-    #     """Match the Glyphs python API"""
-    #     with self.assertRaises(AttributeError):
-    #         self.font.masters[0].name = "Test"
-
     # TODO: selection, selectedLayers, currentText, tabs, currentTab
 
     # TODO: selectedFontMaster, masterIndex
@@ -1399,11 +1394,7 @@ class GSNodeFromFileTest(GSObjectsTestCase):
         self.assertEqual(self.node.name, 'Hello')
 
     def test_userData(self):
-        if int(self.font.appVersion) >= 1075:
-            result = "1"
-        else:
-            result = 1
-        self.assertEqual(result, self.node.userData["rememberToMakeCoffee"])
+        self.assertEqual("1", self.node.userData["rememberToMakeCoffee"])
 
     def test_makeNodeFirst(self):
         oldAmount = len(self.path.nodes)

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -429,10 +429,10 @@ class GSFontFromFileTest(GSObjectsTestCase):
         self.assertEqual(amount, len(list(font.customParameters)))
         del font.customParameters['trademark']
 
-    def test_font_master_is_name_not_writable(self):
-        """Match the Glyphs python API"""
-        with self.assertRaises(AttributeError):
-            self.font.masters[0].name = "Test"
+    # def test_font_master_is_name_not_writable(self):
+    #     """Match the Glyphs python API"""
+    #     with self.assertRaises(AttributeError):
+    #         self.font.masters[0].name = "Test"
 
     # TODO: selection, selectedLayers, currentText, tabs, currentTab
 
@@ -1399,7 +1399,11 @@ class GSNodeFromFileTest(GSObjectsTestCase):
         self.assertEqual(self.node.name, 'Hello')
 
     def test_userData(self):
-        self.assertEqual(1, self.node.userData["rememberToMakeCoffee"])
+        if int(self.font.appVersion) >= 1075:
+            result = "1"
+        else:
+            result = 1
+        self.assertEqual(result, self.node.userData["rememberToMakeCoffee"])
 
     def test_makeNodeFirst(self):
         oldAmount = len(self.path.nodes)

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1043";
+.appVersion = "1087";
 DisplayStrings = (
 A
 );
@@ -70,16 +70,19 @@ customParameters = (
 name = TTFStems;
 value = (
 {
-Name = Thin;
-Width = 16;
+horizontal = 1;
+name = Thin;
+width = 16;
 },
 {
-Name = Lowercase;
-Width = 16;
+horizontal = 1;
+name = Lowercase;
+width = 16;
 },
 {
-Name = Uppercase;
-Width = 18;
+horizontal = 1;
+name = Uppercase;
+width = 18;
 }
 );
 }
@@ -104,7 +107,9 @@ horizontalStems = (
 16,
 18
 );
+iconName = Light;
 id = "C4872ECA-A3A9-40AB-960A-1DB2202F16DE";
+name = Light;
 userData = {
 GSOffsetHorizontal = 9;
 GSOffsetMakeStroke = 1;
@@ -136,16 +141,19 @@ customParameters = (
 name = TTFStems;
 value = (
 {
-Name = Thin;
-Width = 80;
+horizontal = 1;
+name = Thin;
+width = 80;
 },
 {
-Name = Lowercase;
-Width = 88;
+horizontal = 1;
+name = Lowercase;
+width = 88;
 },
 {
-Name = Uppercase;
-Width = 91;
+horizontal = 1;
+name = Uppercase;
+width = 91;
 }
 );
 }
@@ -177,6 +185,7 @@ horizontalStems = (
 88,
 91
 );
+iconName = Regular;
 id = "3E7589AA-8194-470F-8E2F-13C1C581BE24";
 userData = {
 GSOffsetHorizontal = 45;
@@ -208,16 +217,19 @@ customParameters = (
 name = TTFStems;
 value = (
 {
-Name = Thin;
-Width = 108;
+horizontal = 1;
+name = Thin;
+width = 108;
 },
 {
-Name = Lowercase;
-Width = 210;
+horizontal = 1;
+name = Lowercase;
+width = 210;
 },
 {
-Name = Uppercase;
-Width = 215;
+horizontal = 1;
+name = Uppercase;
+width = 215;
 }
 );
 }
@@ -245,7 +257,9 @@ horizontalStems = (
 210,
 215
 );
+iconName = Bold;
 id = "BFFFD157-90D3-4B85-B99D-9A2F366F03CA";
+name = Bold;
 userData = {
 GSOffsetHorizontal = 115;
 GSOffsetMakeStroke = 1;
@@ -422,7 +436,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"321 700 LINE {\nname = \"Hello World\";\n}",
+"321 700 LINE {name = \"Hello World\";}",
 "275 700 LINE",
 "45 0 LINE",
 "65 0 LINE",
@@ -843,7 +857,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"352 147 LINE SMOOTH {\nname = Hello;\nrememberToMakeCoffee = 1;\n}",
+"352 147 LINE SMOOTH {name = Hello;\nrememberToMakeCoffee = \"1\";}",
 "352 68 OFFCURVE",
 "314 7 OFFCURVE",
 "212 7 CURVE SMOOTH",
@@ -3362,7 +3376,6 @@ kerning = {
 };
 };
 };
-keyboardIncrement = 0;
 unitsPerEm = 1000;
 userData = {
 AsteriskParameters = {

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -334,6 +334,7 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
             );
             id = "MASTER-ID";
             italicAngle = 12.2;
+            name = "Hairline Megawide";
             userData = {
             rememberToMakeTea = 1;
             };
@@ -910,8 +911,8 @@ class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):
         node.userData["rememberToDownloadARealRemindersApp"] = True
         self.assertWritesValue(
             node,
-            '"10 30 CURVE SMOOTH {\\nname = \\"top-left corner\\";\\n\
-rememberToDownloadARealRemindersApp = 1;\\n}"'
+            '"10 30 CURVE SMOOTH {name = \\"top-left corner\\";\\n\
+rememberToDownloadARealRemindersApp = 1;}"'
         )
 
         # Write floating point coordinates


### PR DESCRIPTION
https://github.com/googlei18n/fontmake/issues/374
In Glyphs 2.5b fontMaster has "name" and "iconName" properties. The name property conflicts with the GSFontMaster name property in the parser. 