### PR TITLE
support useProductionNames lib key from ufo2ft

### DIFF
--- a/Lib/glyphsLib/builder/constants.py
+++ b/Lib/glyphsLib/builder/constants.py
@@ -20,6 +20,7 @@ GLYPHS_PREFIX = 'com.schriftgestaltung.'
 GLYPHLIB_PREFIX = GLYPHS_PREFIX + 'Glyphs.'
 ROBOFONT_PREFIX = 'com.typemytype.robofont.'
 UFO2FT_FILTERS_KEY = 'com.github.googlei18n.ufo2ft.filters'
+UFO2FT_USE_PROD_NAMES_KEY = 'com.github.googlei18n.ufo2ft.useProductionNames'
 
 GLYPHS_COLORS = (
     '0.85,0.26,0.06,1',

--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -20,7 +20,7 @@ import re
 from glyphsLib.util import bin_to_int_list
 from .filters import parse_glyphs_filter
 from .constants import (GLYPHS_PREFIX, PUBLIC_PREFIX, CODEPAGE_RANGES,
-                        UFO2FT_FILTERS_KEY)
+                        UFO2FT_FILTERS_KEY, UFO2FT_USE_PROD_NAMES_KEY)
 from .features import replace_feature
 
 
@@ -57,6 +57,11 @@ def set_custom_params(ufo, parsed=None, data=None, misc_keys=(), non_info=()):
     fsSelection_flags = {'Use Typo Metrics', 'Has WWS Names'}
     for name, value in parsed:
         name = normalize_custom_param_name(name)
+
+        if name == "Don't use Production Names":
+            # convert between Glyphs.app's and ufo2ft's equivalent parameter
+            ufo.lib[UFO2FT_USE_PROD_NAMES_KEY] = not value
+            continue
 
         if name in fsSelection_flags:
             if value:

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -45,8 +45,9 @@ from glyphsLib.builder.custom_params import (set_custom_params,
                                              set_default_params)
 from glyphsLib.builder.names import build_stylemap_names, build_style_name
 from glyphsLib.builder.filters import parse_glyphs_filter
-from glyphsLib.builder.constants import (GLYPHS_PREFIX, PUBLIC_PREFIX,
-                                         GLYPHLIB_PREFIX)
+from glyphsLib.builder.constants import (
+    GLYPHS_PREFIX, PUBLIC_PREFIX, GLYPHLIB_PREFIX,
+    UFO2FT_USE_PROD_NAMES_KEY)
 
 from classes_test import (generate_minimal_font, generate_instance_from_dict,
                           add_glyph, add_anchor, add_component)
@@ -424,6 +425,15 @@ class SetCustomParamsTest(unittest.TestCase):
         set_custom_params(self.ufo, parsed=[("Replace Feature", repl)])
 
         self.assertEqual(self.ufo.features.text, original)
+
+    def test_useProductionNames(self):
+        for value in (True, False):
+            glyphs_param = ("Don't use Production Names", value)
+            set_custom_params(self.ufo, parsed=[glyphs_param])
+
+            self.assertIn(UFO2FT_USE_PROD_NAMES_KEY, self.ufo.lib)
+            self.assertEqual(self.ufo.lib[UFO2FT_USE_PROD_NAMES_KEY],
+                             not value)
 
 
 class ParseGlyphsFilterTest(unittest.TestCase):


### PR DESCRIPTION
Follow up from https://github.com/googlei18n/ufo2ft/pull/186

I want to deprecate the code in fontmake that reads "com.schriftgestaltung.Don't use Production Names" UFO lib key, and handle this inside ufo2ft postProcessor using a non-glyphs-app-specific key  "com.github.googlei18n.ufo2ft.useProductionNames"

I guess @belluzj would have to convert it back to the Glyphs.app equivalent in the roundtrip branch.