### PR TITLE
fix: do not fetch license info when using external xml

### DIFF
--- a/MetaTools/generate_glyphdata.py
+++ b/MetaTools/generate_glyphdata.py
@@ -211,12 +211,12 @@ def generate_python_source(data, out):
             "#\n"
             % fetch_data_version())
 
-    for paragraph in fetch("LICENSE").strip().split("\n\n"):
-        out.write("#\n")
-        for line in textwrap.wrap(paragraph):
-            out.write("# ")
-            out.write(line)
-            out.write("\n")
+        for paragraph in fetch("LICENSE").strip().split("\n\n"):
+            out.write("#\n")
+            for line in textwrap.wrap(paragraph):
+                out.write("# ")
+                out.write(line)
+                out.write("\n")
 
     out.write("\nfrom __future__ import unicode_literals\n\n\n")
     out.write(


### PR DESCRIPTION
In Debian's case, we don't want to access the internet for fetching any file during build time, so we want to get rid of the license fetching as well.  We can put the license in our [debian/copyright](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/) file.