### PR TITLE
[builder.names] set empty weight string if 'Regular'

### DIFF
--- a/Lib/glyphsLib/builder/names.py
+++ b/Lib/glyphsLib/builder/names.py
@@ -26,7 +26,7 @@ def to_ufo_names(self, ufo, master, family_name):
 
     styleName = build_style_name(
         width if width != 'Regular' else '',
-        weight,
+        weight if weight != 'Regular' else '',
         custom,
         is_italic
     )


### PR DESCRIPTION
same as we do for the 'width'.

Fixes https://github.com/googlei18n/glyphsLib/issues/300