### PR TITLE
Make to target UFOs filenames unique if masters have the same style name

### DIFF
--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -53,6 +53,15 @@ def _to_designspace_source(self, master, is_regular):
         source.filename = build_ufo_path(
             '', source.familyName, source.styleName)
 
+        # Make sure UFO filenames are unique, lest we overwrite masters that
+        # happen to have the same weight name.
+        n = "_"
+        while any(s != source and s.filename == source.filename
+                  for s in self._sources.values()):
+            source.filename = os.path.basename(
+                build_ufo_path('.', source.familyName, source.styleName + n))
+            n += "_"
+
     location = {}
     for axis_def in get_axis_definitions(self.font):
         location[axis_def.name] = axis_def.get_design_loc(master)

--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -15,6 +15,7 @@
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
+import logging
 import os
 
 from glyphsLib.util import build_ufo_path
@@ -22,6 +23,9 @@ from glyphsLib.util import build_ufo_path
 from .masters import UFO_FILENAME_KEY
 from .axes import (get_axis_definitions, get_regular_master,
                    font_uses_new_axes, interp)
+
+
+logger = logging.getLogger(__name__)
 
 
 def to_designspace_sources(self):
@@ -61,6 +65,12 @@ def _to_designspace_source(self, master, is_regular):
             source.filename = os.path.basename(
                 build_ufo_path('.', source.familyName, source.styleName + n))
             n += "_"
+            logger.warn("The master with id {} has the same style name ({}) "
+                        "as another one. All masters should have distinctive "
+                        "(style) names. Use the 'Master name' custom parameter"
+                        " on a master to give it a unique name. Proceeding "
+                        "with an unchanged name, but appending '_' to the file"
+                        " name on disk.".format(master.id, source.styleName))
 
     location = {}
     for axis_def in get_axis_definitions(self.font):

--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -60,10 +60,10 @@ def _to_designspace_source(self, master, is_regular):
         # Make sure UFO filenames are unique, lest we overwrite masters that
         # happen to have the same weight name.
         n = "_"
-        while any(s != source and s.filename == source.filename
+        while any(s is not source and s.filename == source.filename
                   for s in self._sources.values()):
             source.filename = os.path.basename(
-                build_ufo_path('.', source.familyName, source.styleName + n))
+                build_ufo_path('', source.familyName, source.styleName + n))
             n += "_"
             logger.warn("The master with id {} has the same style name ({}) "
                         "as another one. All masters should have distinctive "

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -128,3 +128,24 @@ def test_designspace_generation_regular_different_family_names(tmpdir):
     # REVIEW: reasonable requirement?
     with pytest.raises(Exception):
         font = to_glyphs([ufo_Lt, ufo_Rg])
+
+
+def test_designspace_generation_same_weight_name(tmpdir):
+    ufo_Bd = defcon.Font()
+    ufo_Bd.info.familyName = 'Test'
+    ufo_Bd.info.styleName = 'Bold'
+
+    ufo_ExBd = defcon.Font()
+    ufo_ExBd.info.familyName = 'Test'
+    ufo_ExBd.info.styleName = 'Bold'
+
+    ufo_XExBd = defcon.Font()
+    ufo_XExBd.info.familyName = 'Test'
+    ufo_XExBd.info.styleName = 'Bold'
+
+    font = to_glyphs([ufo_Bd, ufo_ExBd, ufo_XExBd])
+    designspace = to_designspace(font)
+
+    assert designspace.sources[0].filename != designspace.sources[1].filename
+    assert designspace.sources[1].filename != designspace.sources[2].filename
+    assert designspace.sources[0].filename != designspace.sources[2].filename


### PR DESCRIPTION
Found this when a colleague made a six master glyphs file, where Glyphs provides just five different weight names; he just made the two boldest ones "Bold". Before, we would  overwrite the first with the second.