### PR TITLE
mute "layer without name" warning if minimize_glyphs_diff=False

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -154,19 +154,22 @@ class UFOBuilder(_LoggerMixin):
         for glyph, layer in supplementary_layer_data:
             if (layer.layerId not in master_layer_ids and
                     layer.associatedMasterId not in master_layer_ids):
-                self.logger.warning(
-                    '{}, glyph "{}": Layer "{}" is dangling and will be '
-                    'skipped. Did you copy a glyph from a different font? If '
-                    'so, you should clean up any phantom layers not associated '
-                    'with an actual master.'.format(self.font.familyName,
-                                                    glyph.name, layer.layerId))
+                if self.minimize_glyphs_diffs:
+                    self.logger.warning(
+                        '{}, glyph "{}": Layer "{}" is dangling and will be '
+                        'skipped. Did you copy a glyph from a different font?'
+                        ' If so, you should clean up any phantom layers not '
+                        'associated with an actual master.'.format(
+                            self.font.familyName, glyph.name, layer.layerId))
                 continue
 
             if not layer.name:
                 # Empty layer names are invalid according to the UFO spec.
-                self.logger.warning(
-                    '{}, glyph "{}": Contains layer without a name which will '
-                    'be skipped.'.format(self.font.familyName, glyph.name))
+                if self.minimize_glyphs_diffs:
+                    self.logger.warning(
+                        '{}, glyph "{}": Contains layer without a name which '
+                        'will be skipped.'.format(self.font.familyName,
+                                                  glyph.name))
                 continue
 
             ufo_layer = self.to_ufo_layer(glyph, layer)

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -1142,16 +1142,22 @@ class SkipDanglingAndNamelessLayers(unittest.TestCase):
         self.font.glyphs[0].layers[0].associatedMasterId = "xxx"
 
         with CapturingLogHandler(self.logger, level="WARNING") as captor:
-            to_ufos(self.font)
+            to_ufos(self.font, minimize_glyphs_diffs=True)
 
         captor.assertRegex("layer without a name")
+
+        # no warning if minimize_glyphs_diff=False
+        with CapturingLogHandler(self.logger, level="WARNING") as captor:
+            to_ufos(self.font, minimize_glyphs_diffs=False)
+
+        self.assertFalse(captor.records)
 
     def test_dangling_layer(self):
         self.font.glyphs[0].layers[0].layerId = "yyy"
         self.font.glyphs[0].layers[0].associatedMasterId = "xxx"
 
         with CapturingLogHandler(self.logger, level="WARNING") as captor:
-            to_ufos(self.font)
+            to_ufos(self.font, minimize_glyphs_diffs=True)
 
         captor.assertRegex("is dangling and will be skipped")
 


### PR DESCRIPTION
it can be very chatty, especially on some fonts which have tons of these
https://github.com/googlei18n/noto-source/issues/114

How often does this situation happen? It's unlikely that such name-less layers are one of the master-linked layers -- which are the ones that fontmake cares about for building fonts.