### PR TITLE
Fixes for designspace axes, and for UFO instances weight/width class

### DIFF
--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -71,11 +71,10 @@ def user_loc_string_to_value(axis_tag, user_loc):
     Returns None if the string is invalid.
 
     >>> user_loc_string_to_value('wght', 'ExtraLight')
-    250
+    200
     >>> user_loc_string_to_value('wdth', 'SemiCondensed')
     87.5
     >>> user_loc_string_to_value('wdth', 'Clearly Not From Glyphs UI')
-    None
     """
     if axis_tag == 'wght':
         try:
@@ -100,7 +99,7 @@ def user_loc_value_to_class(axis_tag, user_loc):
     width it is a percentage.
 
     >>> user_loc_value_to_class('wght', 310)
-    300
+    310
     >>> user_loc_value_to_class('wdth', 62)
     2
     """
@@ -117,9 +116,9 @@ def user_loc_value_to_instance_string(axis_tag, user_loc):
     """Return the Glyphs UI string (from the instance dropdown) that is
     closest to the provided user location.
 
-    >>> user_loc_value_to_string('wght', 430)
-    'Regular'
-    >>> user_loc_value_to_string('wdth', 150)
+    >>> user_loc_value_to_instance_string('wght', 430)
+    'Normal'
+    >>> user_loc_value_to_instance_string('wdth', 150)
     'Extra Expanded'
     """
     codes = {}
@@ -525,7 +524,7 @@ def is_instance_active(instance):
 def interp(mapping, x):
     """Compute the piecewise linear interpolation given by mapping for input x.
 
-    >>> _interp(((1, 1), (2, 4)), 1.5)
+    >>> interp(((1, 1), (2, 4)), 1.5)
     2.5
     """
     mapping = sorted(mapping)

--- a/Lib/glyphsLib/builder/axes.py
+++ b/Lib/glyphsLib/builder/axes.py
@@ -16,6 +16,7 @@ from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
 from collections import OrderedDict
+import logging
 
 from glyphsLib import classes
 from glyphsLib.classes import WEIGHT_CODES, WIDTH_CODES
@@ -37,6 +38,8 @@ WIDTH_CLASS_TO_VALUE = {
     8: 150,  # Extra-expanded
     9: 200,  # Ultra-expanded
 }
+
+logger = logging.getLogger(__name__)
 
 
 def class_to_value(axis, ufo_class):
@@ -148,33 +151,37 @@ def to_designspace_axes(self):
         if font_uses_new_axes(self.font):
             # Build the mapping from the "Axis Location" of the masters
             # TODO: (jany) use Virtual Masters as well?
-            mapping = []
+            mapping = {}
             for master in self.font.masters:
                 designLoc = axis_def.get_design_loc(master)
                 userLoc = axis_def.get_user_loc(master)
-                mapping.append((userLoc, designLoc))
-            mapping = sorted(set(mapping))
+                if userLoc in mapping and mapping[userLoc] != designLoc:
+                    logger.warning("Axis location (%s) was redefined by '%s'",
+                                   userLoc, master.name)
+                mapping[userLoc] = designLoc
 
             regularDesignLoc = axis_def.get_design_loc(regular_master)
             regularUserLoc = axis_def.get_user_loc(regular_master)
         else:
             # Build the mapping from the isntances because they have both
             # a user location and a design location.
-            instance_mapping = []
+            instance_mapping = {}
             for instance in self.font.instances:
                 if is_instance_active(instance) or self.minimize_glyphs_diffs:
                     designLoc = axis_def.get_design_loc(instance)
                     userLoc = axis_def.get_user_loc(instance)
-                    instance_mapping.append((userLoc, designLoc))
-            instance_mapping = sorted(set(instance_mapping))  # avoid duplicates
+                    if (userLoc in instance_mapping and
+                            instance_mapping[userLoc] != designLoc):
+                        logger.warning(
+                            "Instance user-space location (%s) redefined by "
+                            "'%s'", userLoc, instance.name)
+                    instance_mapping[userLoc] = designLoc
 
-            master_mapping = []
+            master_mapping = {}
             for master in self.font.masters:
-                designLoc = axis_def.get_design_loc(master)
                 # Glyphs masters don't have a user location
-                userLoc = designLoc
-                master_mapping.append((userLoc, designLoc))
-            master_mapping = sorted(set(master_mapping))
+                userLoc = designLoc = axis_def.get_design_loc(master)
+                master_mapping[userLoc] = designLoc
 
             # Prefer the instance-based mapping
             mapping = instance_mapping or master_mapping
@@ -182,18 +189,19 @@ def to_designspace_axes(self):
             regularDesignLoc = axis_def.get_design_loc(regular_master)
             # Glyphs masters don't have a user location, so we compute it by
             # looking at the axis mapping in reverse.
-            reverse_mapping = [(dl, ul) for ul, dl in mapping]
+            reverse_mapping = [(dl, ul) for ul, dl in sorted(mapping.items())]
             regularUserLoc = interp(reverse_mapping, regularDesignLoc)
+            # TODO make sure that the default is in mapping?
 
-        minimum = maximum = default = axis_def.default_user_loc
-        if mapping:
-            minimum = min([userLoc for userLoc, _ in mapping])
-            maximum = max([userLoc for userLoc, _ in mapping])
-            default = min(maximum, max(minimum, regularUserLoc))  # clamp
+        minimum = min(mapping)
+        maximum = max(mapping)
+        default = min(maximum, max(minimum, regularUserLoc))  # clamp
 
+        is_identity_map = all(uloc == dloc for uloc, dloc in mapping.items())
         if (minimum < maximum or minimum != axis_def.default_user_loc or
-                len(instance_mapping) > 1 or len(master_mapping) > 1):
-            axis.map = mapping
+                not is_identity_map):
+            if not is_identity_map:
+                axis.map = sorted(mapping.items())
             axis.minimum = minimum
             axis.maximum = maximum
             axis.default = default

--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -293,18 +293,17 @@ def _set_class_from_instance(ufo, designspace, instance, axis_tag):
     try:
         design_loc = instance.location[axis_def.name]
     except KeyError:
-        # The location does not have this axis. Use default value
-        design_loc = axis_def.default_user_loc
-
-    if mapping:
-        # Retrieve the user location (weightClass/widthClass)
-        # by going through the axis mapping in reverse.
-        reverse_mapping = sorted({dl: ul for ul, dl in mapping}.items())
-        user_loc = interp(reverse_mapping, design_loc)
-        axis_def.set_ufo_user_loc(ufo, user_loc)
+        user_loc = axis_def.default_user_loc
     else:
-        # no mapping means user space location is same as design space
-        axis_def.set_ufo_user_loc(ufo, design_loc)
+        if mapping:
+            # Retrieve the user location (weightClass/widthClass)
+            # by going through the axis mapping in reverse.
+            reverse_mapping = sorted({dl: ul for ul, dl in mapping}.items())
+            user_loc = interp(reverse_mapping, design_loc)
+        else:
+            # no mapping means user space location is same as design space
+            user_loc = design_loc
+    axis_def.set_ufo_user_loc(ufo, user_loc)
 
 
 def set_weight_class(ufo, designspace, instance):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -151,9 +151,9 @@ RTLTTB = 2
 
 
 WEIGHT_CODES = {
-    'Thin': 250,
-    'ExtraLight': 250,
-    'UltraLight': 250,
+    'Thin': 100,
+    'ExtraLight': 200,
+    'UltraLight': 200,
     'Light': 300,
     None: 400,  # default value normally omitted in source
     'Normal': 400,

--- a/tests/builder/interpolation_test.py
+++ b/tests/builder/interpolation_test.py
@@ -395,18 +395,14 @@ WIDTH_CLASS_KEY = GLYPHS_PREFIX + "widthClass"
 
 class SetWeightWidthClassesTest(unittest.TestCase):
 
-    def test_no_weigth_class(self):
+    def test_no_weight_class(self):
         ufo = defcon.Font()
-        # name here says "Bold", however no excplit weightClass
+        # name here says "Bold", however no explicit weightClass
         # is assigned
         doc, instance = makeInstanceDescriptor("Bold")
         set_weight_class(ufo, doc, instance)
         # the default OS/2 weight class is set
         self.assertEqual(ufo.info.openTypeOS2WeightClass, 400)
-        # non-empty value is stored in the UFO lib even if same as default
-        # FIXME: (jany) why do we want to write something Glyphs-specific in
-        #   the instance UFO? Does someone later in the toolchain rely on it?
-        # self.assertEqual(ufo.lib[WEIGHT_CLASS_KEY], "Regular")
 
     def test_weight_class(self):
         ufo = defcon.Font()
@@ -416,9 +412,7 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         )
 
         set_weight_class(ufo, doc, data)
-
         self.assertEqual(ufo.info.openTypeOS2WeightClass, 700)
-        # self.assertEqual(ufo.lib[WEIGHT_CLASS_KEY], "Bold")
 
     def test_explicit_default_weight(self):
         ufo = defcon.Font()
@@ -430,8 +424,6 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         set_weight_class(ufo, doc, data)
         # the default OS/2 weight class is set
         self.assertEqual(ufo.info.openTypeOS2WeightClass, 400)
-        # non-empty value is stored in the UFO lib even if same as default
-        # self.assertEqual(ufo.lib[WEIGHT_CLASS_KEY], "Regular")
 
     def test_no_width_class(self):
         ufo = defcon.Font()
@@ -440,8 +432,6 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         set_width_class(ufo, doc, data)
         # the default OS/2 width class is set
         self.assertEqual(ufo.info.openTypeOS2WidthClass, 5)
-        # non-empty value is stored in the UFO lib even if same as default
-        # self.assertEqual(ufo.lib[WIDTH_CLASS_KEY], "Medium (normal)")
 
     def test_width_class(self):
         ufo = defcon.Font()
@@ -451,9 +441,7 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         )
 
         set_width_class(ufo, doc, data)
-
         self.assertEqual(ufo.info.openTypeOS2WidthClass, 3)
-        # self.assertEqual(ufo.lib[WIDTH_CLASS_KEY], "Condensed")
 
     def test_explicit_default_width(self):
         ufo = defcon.Font()
@@ -465,8 +453,6 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         set_width_class(ufo, doc, data)
         # the default OS/2 width class is set
         self.assertEqual(ufo.info.openTypeOS2WidthClass, 5)
-        # non-empty value is stored in the UFO lib even if same as default
-        # self.assertEqual(ufo.lib[WIDTH_CLASS_KEY], "Medium (normal)")
 
     def test_weight_and_width_class(self):
         ufo = defcon.Font()
@@ -480,9 +466,7 @@ class SetWeightWidthClassesTest(unittest.TestCase):
         set_width_class(ufo, doc, data)
 
         self.assertEqual(ufo.info.openTypeOS2WeightClass, 800)
-        # self.assertEqual(ufo.lib[WEIGHT_CLASS_KEY], "ExtraBold")
         self.assertEqual(ufo.info.openTypeOS2WidthClass, 4)
-        # self.assertEqual(ufo.lib[WIDTH_CLASS_KEY], "SemiCondensed")
 
     def test_unknown_ui_string_but_defined_weight_class(self):
         ufo = defcon.Font()
@@ -518,11 +502,8 @@ class SetWeightWidthClassesTest(unittest.TestCase):
 
         set_weight_class(ufo, doc, data)
 
-        # we do not set any OS/2 weight class; user needs to provide
-        # a 'weightClass' custom parameter in this special case
-        # FIXME: (jany) the new code writes the default OS2 class instead of
-        #   None. Is that a problem?
-        self.assertTrue(ufo.info.openTypeOS2WeightClass == 400)
+        # the default OS/2 weight class is set
+        self.assertEqual(ufo.info.openTypeOS2WeightClass, 400)
 
 
 def test_apply_instance_data(tmpdir):

--- a/tests/data/DesignspaceGenTestItalic.designspace
+++ b/tests/data/DesignspaceGenTestItalic.designspace
@@ -3,11 +3,6 @@
     <axes>
         <axis default="400" maximum="800" minimum="300" name="Weight" tag="wght">
             <labelname xml:lang="en">Weight</labelname>
-            <map input="300" output="300" />
-            <map input="400" output="400" />
-            <map input="500" output="500" />
-            <map input="700" output="700" />
-            <map input="800" output="800" />
         </axis>
     </axes>
     <sources>

--- a/tests/data/DesignspaceGenTestRegular.designspace
+++ b/tests/data/DesignspaceGenTestRegular.designspace
@@ -3,11 +3,6 @@
     <axes>
         <axis default="400" maximum="800" minimum="300" name="Weight" tag="wght">
             <labelname xml:lang="en">Weight</labelname>
-            <map input="300" output="300" />
-            <map input="400" output="400" />
-            <map input="500" output="500" />
-            <map input="700" output="700" />
-            <map input="800" output="800" />
         </axis>
     </axes>
     <sources>

--- a/tests/data/DesignspaceTestTwoAxes.designspace
+++ b/tests/data/DesignspaceTestTwoAxes.designspace
@@ -10,8 +10,6 @@
         </axis>
         <axis default="100" maximum="100" minimum="70" name="Width" tag="wdth">
             <labelname xml:lang="en">Width</labelname>
-            <map input="70" output="70" />
-            <map input="100" output="100" />
         </axis>
     </axes>
     <sources>

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -2320,6 +2320,12 @@ name = Black;
 weightClass = Black;
 },
 {
+customParameters = (
+{
+name = weightClass;
+value = 357;
+}
+);
 interpolationWeight = 75;
 instanceInterpolations = {
 "3E7589AA-8194-470F-8E2F-13C1C581BE24" = 0.79452;


### PR DESCRIPTION
- don't write axis map elements if all input == output 
- don't write conflicting mappings (the same input maps to different outputs); if these occur (either because "Axis Location" parameters point different masters to same user-space location, or different instances have the same user-space location), then use the last occurrence but also warn the user about the mapping been redefined (would it be better to raise? see #341)
- Drop the legacy `250` value for default Thin, ExtraLight and UltraLight OS/2 weight classes. The latest Glyphs.app beta uses 100 and 200, so we do the same here.
- when setting OS/2 weight/width of UFO instances in apply_instance_data, look up weight and width axes by their tag rather than the name (which may not always be "Weight" or "Width")
