### PR TITLE
Add tests for disabled and automatic features, fix roundtripping them

### DIFF
--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -507,6 +507,7 @@ class FeatureFileProcessor(object):
             feature.notes = notes_text
         if disabled:
             feature.code = disabled_text
+            feature.disabled = True
             # FIXME: (jany) check that the user has not added more new code
             #    after the disabled comment. Maybe start by checking whether
             #    the block is only made of comments
@@ -572,7 +573,7 @@ class FeatureFileProcessor(object):
         # Keep the rest of the statements
         res.extend(list(st_iter))
         # Inside the comment block, drop the pound sign and any common indent
-        return (match, dedent(''.join(line[1:] for line in comments)), res)
+        return (match, dedent(''.join(c.text[1:] for c in comments)), res)
 
     def _rstrip_newlines(self, string, number=1):
         if len(string) >= number and string[-number:] == '\n' * number:

--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -573,7 +573,8 @@ class FeatureFileProcessor(object):
         # Keep the rest of the statements
         res.extend(list(st_iter))
         # Inside the comment block, drop the pound sign and any common indent
-        return (match, dedent(''.join(c.text[1:] for c in comments)), res)
+        return (match, dedent(''.join(c.text[1:] + "\n" for c in comments)),
+                res)
 
     def _rstrip_newlines(self, string, number=1):
         if len(string) >= number and string[-number:] == '\n' * number:

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -276,3 +276,49 @@ def test_different_features_in_different_UFOS(tmpdir):
 
     assert ufo1rt.features.text == ufo1.features.text
     assert ufo2rt.features.text == ufo2.features.text
+
+
+def test_roundtrip_disabled_feature():
+    font = to_glyphs([defcon.Font()])
+    feature = classes.GSFeature(name="ccmp")
+    feature.code = "sub c by c.ss03;"
+    feature.disabled = True
+    font.features.append(feature)
+
+    ufo, = to_ufos(font)
+    assert ufo.features.text == dedent('''\
+        feature ccmp {
+        # disabled
+        #sub c by c.ss03;
+        } ccmp;
+    ''')
+
+    font_r = to_glyphs([ufo])
+    assert len(font_r.features) == 1
+    feature_r = font_r.features[0]
+    assert feature_r.name == "ccmp"
+    assert feature_r.code == "sub c by c.ss03;"
+    assert feature_r.disabled is True
+
+
+def test_roundtrip_automatic_feature():
+    font = to_glyphs([defcon.Font()])
+    feature = classes.GSFeature(name="ccmp")
+    feature.code = "sub c by c.ss03;"
+    feature.automatic = True
+    font.features.append(feature)
+
+    ufo, = to_ufos(font)
+    assert ufo.features.text == dedent('''\
+        feature ccmp {
+        # automatic
+        sub c by c.ss03;
+        } ccmp;
+    ''')
+
+    font_r = to_glyphs([ufo])
+    assert len(font_r.features) == 1
+    feature_r = font_r.features[0]
+    assert feature_r.name == "ccmp"
+    assert feature_r.code == "sub c by c.ss03;"
+    assert feature_r.automatic is True

--- a/tests/builder/features_test.py
+++ b/tests/builder/features_test.py
@@ -281,7 +281,11 @@ def test_different_features_in_different_UFOS(tmpdir):
 def test_roundtrip_disabled_feature():
     font = to_glyphs([defcon.Font()])
     feature = classes.GSFeature(name="ccmp")
-    feature.code = "sub c by c.ss03;"
+    feature.code = dedent("""\
+        sub a by a.ss03;
+        sub b by b.ss03;
+        sub c by c.ss03;
+    """)
     feature.disabled = True
     font.features.append(feature)
 
@@ -289,6 +293,8 @@ def test_roundtrip_disabled_feature():
     assert ufo.features.text == dedent('''\
         feature ccmp {
         # disabled
+        #sub a by a.ss03;
+        #sub b by b.ss03;
         #sub c by c.ss03;
         } ccmp;
     ''')
@@ -297,8 +303,15 @@ def test_roundtrip_disabled_feature():
     assert len(font_r.features) == 1
     feature_r = font_r.features[0]
     assert feature_r.name == "ccmp"
-    assert feature_r.code == "sub c by c.ss03;"
+    assert feature_r.code == feature.code
     assert feature_r.disabled is True
+
+    font_rr = to_glyphs(to_ufos(font_r))
+    assert len(font_rr.features) == 1
+    feature_rr = font_rr.features[0]
+    assert feature_rr.name == "ccmp"
+    assert feature_rr.code == feature.code
+    assert feature_rr.disabled is True
 
 
 def test_roundtrip_automatic_feature():


### PR DESCRIPTION
The code was trying to subscript an `ast.Comment` object before. Get the `.text` property instead for subscription.

When are we going to use type hints + mypy to catch these kinds of errors sooner? 😁 