### PR TITLE
Fix GSFontMaster.name

### DIFF
--- a/Lib/glyphsLib/builder/names.py
+++ b/Lib/glyphsLib/builder/names.py
@@ -34,12 +34,7 @@ def to_ufo_names(self, ufo, master, family_name):
 
     is_italic = bool(master.italicAngle)
 
-    styleName = master.name or build_style_name(
-        width if width != 'Medium (normal)' else '',
-        weight if weight != 'Regular' else '',
-        custom,
-        is_italic
-    )
+    styleName = master.name
     ufo.info.familyName = family_name
     ufo.info.styleName = styleName
 
@@ -85,16 +80,6 @@ def build_stylemap_names(family_name, style_name, is_bold=False,
     else:
         styleMapFamilyName = family_name
     return styleMapFamilyName, styleMapStyleName
-
-
-def build_style_name(width='', weight='', custom='', is_italic=False):
-    """Build style name from width, weight, and custom style strings
-    and whether the style is italic.
-    """
-
-    return ' '.join(
-        s for s in (custom, width, weight, 'Italic' if is_italic else '') if s
-    ) or 'Regular'
 
 
 def _get_linked_style(style_name, is_bold, is_italic):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1352,8 +1352,8 @@ class GSFontMaster(GSBase):
         # Remove all occurences of 'Regular'
         while len(names) > 1 and "Regular" in names:
             names.remove("Regular")
-        # if abs(self.italicAngle) > 0.01:
-        #     names.append("Italic")
+        if bool(self.italicAngle):
+            names.append("Italic")
         return " ".join(list(names))
 
     def _splitName(self, value):

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -38,7 +38,7 @@ from glyphsLib.types import Point
 from glyphsLib.builder import to_ufos, to_glyphs
 from glyphsLib.builder.builders import UFOBuilder, GlyphsBuilder
 from glyphsLib.builder.paths import to_ufo_paths
-from glyphsLib.builder.names import build_stylemap_names, build_style_name
+from glyphsLib.builder.names import build_stylemap_names
 from glyphsLib.builder.filters import parse_glyphs_filter
 from glyphsLib.builder.constants import (
     GLYPHS_PREFIX, PUBLIC_PREFIX, GLYPHLIB_PREFIX,
@@ -47,40 +47,6 @@ from glyphsLib.builder.constants import (
 
 from classes_test import (generate_minimal_font, generate_instance_from_dict,
                           add_glyph, add_anchor, add_component)
-
-
-class BuildStyleNameTest(unittest.TestCase):
-
-    def test_style_regular_weight(self):
-        self.assertEqual(build_style_name(is_italic=False), 'Regular')
-        self.assertEqual(build_style_name(is_italic=True), 'Italic')
-
-    def test_style_nonregular_weight(self):
-        self.assertEqual(
-            build_style_name(weight='Thin', is_italic=False), 'Thin')
-        self.assertEqual(
-            build_style_name(weight='Thin', is_italic=True), 'Thin Italic')
-
-    def test_style_nonregular_width(self):
-        self.assertEqual(
-            build_style_name(width='Condensed', is_italic=False), 'Condensed')
-        self.assertEqual(
-            build_style_name(width='Condensed', is_italic=True),
-            'Condensed Italic')
-        self.assertEqual(
-            build_style_name(weight='Thin', width='Condensed',
-                             is_italic=False),
-            'Condensed Thin')
-        self.assertEqual(
-            build_style_name(weight='Thin', width='Condensed',
-                             is_italic=True),
-            'Condensed Thin Italic')
-
-    def test_style_custom(self):
-        self.assertEqual(
-            build_style_name(custom='Text', is_italic=False), 'Text')
-        self.assertEqual(
-            build_style_name(weight='Text', is_italic=True), 'Text Italic')
 
 
 class BuildStyleMapNamesTest(unittest.TestCase):

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -567,9 +567,13 @@ class GSFontMasterFromFileTest(GSObjectsTestCase):
         self.assertEqual('Light', master.name)
 
         master.italicAngle = 11
-        # self.assertEqual('Light Italic', master.name)
-        # That doesn't do anything in the latest Glyphs (1114)
-        self.assertEqual('Light', master.name)
+        self.assertEqual('Light Italic', master.name)
+        master.italicAngle = 0
+
+        master.italicAngle = 11
+        master.width = 'Condensed'
+        self.assertEqual('Condensed Light Italic', master.name)
+        master.width = ''
         master.italicAngle = 0
 
         master.customName = 'Rounded'


### PR DESCRIPTION
This fixes a bug where Italic masters without Master Name customParameter would not have the proper master.name generated.

- GSFontMaster.name in Glyphs.app 1114 seemed to not behave properly
- Use same check for Italic as in build_style_name()
- build_style_name() is now a duplicate and is removed
