### PR TITLE
Drop base64; always use hexadecimal strings for binary data

### DIFF
--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -110,10 +110,11 @@ def to_glyphs_master_user_data(self, ufo, master):
 
     # Save UFO data files
     if ufo.data.fileNames:
+        from glyphsLib.types import BinaryData
         ufo_data = {}
         for os_filename in ufo.data.fileNames:
             filename = posixpath.join(*os_filename.split(os.path.sep))
-            ufo_data[filename] = bytearray(ufo.data[os_filename])
+            ufo_data[filename] = BinaryData(ufo.data[os_filename])
         master.userData[UFO_DATA_KEY] = ufo_data
 
 

--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -15,7 +15,6 @@
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
-import binascii
 import os
 import posixpath
 
@@ -51,7 +50,7 @@ def to_ufo_master_user_data(self, ufo, master):
     if UFO_DATA_KEY in master.userData:
         for filename, data in master.userData[UFO_DATA_KEY].items():
             os_filename = os.path.join(*filename.split('/'))
-            ufo.data[os_filename] = binascii.unhexlify(data)
+            ufo.data[os_filename] = bytes(data)
 
 
 def to_ufo_glyph_user_data(self, ufo, glyph):
@@ -114,10 +113,7 @@ def to_glyphs_master_user_data(self, ufo, master):
         ufo_data = {}
         for os_filename in ufo.data.fileNames:
             filename = posixpath.join(*os_filename.split(os.path.sep))
-            data_bytes = binascii.hexlify(ufo.data[os_filename])
-            # FIXME: (jany) The `decode` is here because putting bytes in
-            # userData doesn't work in Python 3. (comes out as `"b'stuff'"`)
-            ufo_data[filename] = data_bytes.decode()
+            ufo_data[filename] = bytearray(ufo.data[os_filename])
         master.userData[UFO_DATA_KEY] = ufo_data
 
 

--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -15,7 +15,7 @@
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
-import base64
+import binascii
 import os
 import posixpath
 
@@ -51,7 +51,7 @@ def to_ufo_master_user_data(self, ufo, master):
     if UFO_DATA_KEY in master.userData:
         for filename, data in master.userData[UFO_DATA_KEY].items():
             os_filename = os.path.join(*filename.split('/'))
-            ufo.data[os_filename] = base64.b64decode(data)
+            ufo.data[os_filename] = binascii.unhexlify(data)
 
 
 def to_ufo_glyph_user_data(self, ufo, glyph):
@@ -114,7 +114,7 @@ def to_glyphs_master_user_data(self, ufo, master):
         ufo_data = {}
         for os_filename in ufo.data.fileNames:
             filename = posixpath.join(*os_filename.split(os.path.sep))
-            data_bytes = base64.b64encode(ufo.data[os_filename])
+            data_bytes = binascii.hexlify(ufo.data[os_filename])
             # FIXME: (jany) The `decode` is here because putting bytes in
             # userData doesn't work in Python 3. (comes out as `"b'stuff'"`)
             ufo_data[filename] = data_bytes.decode()

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -134,7 +134,7 @@ class Parser(object):
         m = self.hex_re.match(text, i)
         if m:
             parsed, value = m.group(0), m.group(1)
-            decoded = binascii.unhexlify(value)
+            decoded = bytearray(binascii.unhexlify(value))
             i += len(parsed)
             return decoded, i
         else:

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -21,7 +21,6 @@ from io import open
 import re
 import logging
 import sys
-import binascii
 
 import glyphsLib
 
@@ -133,8 +132,9 @@ class Parser(object):
 
         m = self.hex_re.match(text, i)
         if m:
+            from glyphsLib.types import BinaryData
             parsed, value = m.group(0), m.group(1)
-            decoded = bytearray(binascii.unhexlify(value))
+            decoded = BinaryData.fromHex(value)
             i += len(parsed)
             return decoded, i
         else:

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -21,7 +21,6 @@ from io import open
 import re
 import logging
 import sys
-import base64
 import binascii
 
 import glyphsLib
@@ -138,14 +137,6 @@ class Parser(object):
             decoded = binascii.unhexlify(value)
             i += len(parsed)
             return decoded, i
-
-        m = self.bytes_re.match(text, i)
-        if m:
-            parsed, value = m.group(0), m.group(1)
-            decoded = base64.b64decode(value)
-            i += len(parsed)
-            return decoded, i
-
         else:
             self._fail('Unexpected content', text, i)
 

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -21,6 +21,7 @@ import datetime
 import traceback
 import math
 import copy
+import binascii
 from fontTools.misc.py23 import unicode
 
 __all__ = [
@@ -372,3 +373,15 @@ class UnicodesList(list):
         if len(self) == 1:
             return self[0]
         return '"%s"' % ','.join(self)
+
+
+class BinaryData(bytes):
+
+    @classmethod
+    def fromHex(cls, data):
+        return cls(binascii.unhexlify(data))
+
+    def plistValue(self):
+        # TODO write hex bytes in chunks and split over multiple lines
+        # for better readability, like the fonttools xmlWriter does
+        return "<%s>" % binascii.hexlify(self).decode()

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -18,9 +18,8 @@
 
 from __future__ import unicode_literals
 import sys
-import binascii
 import glyphsLib.classes
-from glyphsLib.types import floatToString
+from glyphsLib.types import floatToString, BinaryData
 import logging
 import datetime
 from collections import OrderedDict
@@ -139,9 +138,6 @@ class Writer(object):
                 self.file.write("0")
         elif type(value) == datetime.datetime:
             self.file.write("\"%s +0000\"" % str(value))
-        elif isinstance(value, bytearray):
-            value = "<%s>" % binascii.hexlify(value).decode()
-            self.file.write(value)
         else:
             value = unicode(value)
             if forKey != "unicode":

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -19,7 +19,7 @@
 from __future__ import unicode_literals
 import sys
 import glyphsLib.classes
-from glyphsLib.types import floatToString, BinaryData
+from glyphsLib.types import floatToString
 import logging
 import datetime
 from collections import OrderedDict

--- a/Lib/glyphsLib/writer.py
+++ b/Lib/glyphsLib/writer.py
@@ -18,6 +18,7 @@
 
 from __future__ import unicode_literals
 import sys
+import binascii
 import glyphsLib.classes
 from glyphsLib.types import floatToString
 import logging
@@ -138,6 +139,9 @@ class Writer(object):
                 self.file.write("0")
         elif type(value) == datetime.datetime:
             self.file.write("\"%s +0000\"" % str(value))
+        elif isinstance(value, bytearray):
+            value = "<%s>" % binascii.hexlify(value).decode()
+            self.file.write(value)
         else:
             value = unicode(value)
             if forKey != "unicode":

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -15,7 +15,7 @@
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
-import base64
+import binascii
 import os
 import pytest
 from collections import OrderedDict
@@ -109,7 +109,7 @@ def test_ufo_data_into_font_master_user_data(tmpdir):
     # The path in the glyphs file should be os-agnostic (forward slashes)
     assert font.masters[0].userData[GLYPHLIB_PREFIX + 'ufoData'] == {
         # `decode`: not bytes in userData, only strings
-        'org.customTool/ufoData.bin': base64.b64encode(data).decode()
+        'org.customTool/ufoData.bin': binascii.hexlify(data).decode()
     }
 
     ufo, = to_ufos(font)

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -15,7 +15,6 @@
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
-import binascii
 import os
 import pytest
 from collections import OrderedDict
@@ -108,8 +107,7 @@ def test_ufo_data_into_font_master_user_data(tmpdir):
 
     # The path in the glyphs file should be os-agnostic (forward slashes)
     assert font.masters[0].userData[GLYPHLIB_PREFIX + 'ufoData'] == {
-        # `decode`: not bytes in userData, only strings
-        'org.customTool/ufoData.bin': binascii.hexlify(data).decode()
+        'org.customTool/ufoData.bin': bytearray(data)
     }
 
     ufo, = to_ufos(font)

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -22,6 +22,7 @@ from collections import OrderedDict
 import defcon
 from fontTools.designspaceLib import DesignSpaceDocument
 from glyphsLib import classes
+from glyphsLib.types import BinaryData
 from glyphsLib.builder.constants import GLYPHLIB_PREFIX
 
 from glyphsLib import to_glyphs, to_ufos, to_designspace
@@ -107,7 +108,7 @@ def test_ufo_data_into_font_master_user_data(tmpdir):
 
     # The path in the glyphs file should be os-agnostic (forward slashes)
     assert font.masters[0].userData[GLYPHLIB_PREFIX + 'ufoData'] == {
-        'org.customTool/ufoData.bin': bytearray(data)
+        'org.customTool/ufoData.bin': BinaryData(data)
     }
 
     ufo, = to_ufos(font)

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -115,6 +115,9 @@ GSOffsetVertical = 9;
 GSRoughenHorizontal = 15;
 GSRoughenSegmentLength = 15;
 GSRoughenVertical = 10;
+com.schriftgestaltung.Glyphs.ufoData = {
+customBinaryData = <746865206279746573>;
+};
 noodleExtremesAndInflections = 1;
 noodleRemoveOverlap = 0;
 noodleThickness = "106.0";

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -124,12 +124,6 @@ class ParserTest(unittest.TestCase):
             [('outer', OrderedDict([('inner', 'turtles')]))]
         )
 
-    def test_parse_base64_data(self):
-        self.run_test(
-            b'{key = <dmFsdWU=>;}',
-            [('key', b'value')]
-        )
-
     def test_parse_hex_data(self):
         self.run_test(
             b'{key = <48616c6c6f>;}',


### PR DESCRIPTION
The parser will no longer be able to parse and decode base64 encoded strings in .glyphs files.
And the builder will always treat the userData as hexadecimal strings when decoding to/encoding from UFO data files.

See discussion in #352 

Related issue #119  

I think if DaMa has UFO files floating around with base64 data, they can easily write a simple script to re-encode them as hexadecimal strings.