### PR TITLE
Put UFO instances in instance_ufos/ subdirectory by default

### DIFF
--- a/Lib/glyphsLib/builder/instances.py
+++ b/Lib/glyphsLib/builder/instances.py
@@ -83,7 +83,7 @@ def _to_designspace_instance(self, instance):
             fname = self.instance_dir + '/' + os.path.basename(fname)
         ufo_instance.filename = fname
     if not ufo_instance.filename:
-        instance_dir = self.instance_dir or ''
+        instance_dir = self.instance_dir or 'instance_ufos'
         ufo_instance.filename = build_ufo_path(
             instance_dir, ufo_instance.familyName, ufo_instance.styleName)
 


### PR DESCRIPTION
[TestFont.zip](https://github.com/googlei18n/glyphsLib/files/1980923/TestFont.zip)
```
>>> import glyphsLib
>>> a=glyphsLib.load_to_ufos("TestFont.glyphs")
>>> a=glyphsLib.loads("TestFont.glyphs")
>>> d=glyphsLib.to_designspace(a)
>>> [x.filename for x in d.instances]
['instance_ufos/newFont-Regular.ufo', 'instance_ufos/newFont-Medium.ufo', 'instance_ufos/newFont-Bold.ufo']
>>> [x.filename for x in d.sources]
['newFont-Regular.ufo', 'newFont-Bold.ufo']
```