### PR TITLE
Accept os.PathLike objects in GSFont.__init__

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -3003,6 +3003,11 @@ class GSFont(GSBase):
         self._userData = None
 
         if path:
+            # Support os.PathLike objects. 
+            # https://www.python.org/dev/peps/pep-0519/#backwards-compatibility
+            if hasattr(path, "__fspath__"):
+                path = path.__fspath__()
+
             assert isinstance(path, (str, unicode)), \
                 "Please supply a file path"
             assert path.endswith(".glyphs"), \

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -214,7 +214,7 @@ class GSFontFromFileTest(GSObjectsTestCase):
     def setUp(self):
         super(GSFontFromFileTest, self).setUp()
 
-    @pytest.mark.skipif(sys.version_info < (3,4), reason="pathlib available in >= 3.5.")
+    @pytest.mark.skipif(sys.version_info < (3,4), reason="pathlib available in >= 3.4.")
     def test_pathlike_path(self):
         from pathlib import Path
         font = GSFont(TESTFILE_PATH)

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -19,6 +19,7 @@ from __future__ import (
     print_function, division, absolute_import, unicode_literals)
 
 import os
+import sys
 import datetime
 import copy
 import unittest
@@ -212,6 +213,15 @@ class GSObjectsTestCase(unittest.TestCase):
 class GSFontFromFileTest(GSObjectsTestCase):
     def setUp(self):
         super(GSFontFromFileTest, self).setUp()
+
+    @pytest.mark.skipif(sys.version_info < (3,4), reason="pathlib available in >= 3.5.")
+    def test_pathlike_path(self):
+        from pathlib import Path
+        font = GSFont(TESTFILE_PATH)
+        self.assertEqual(font.filepath, TESTFILE_PATH)
+
+        font = GSFont(Path(TESTFILE_PATH))
+        self.assertEqual(font.filepath, TESTFILE_PATH)
 
     def test_masters(self):
         font = self.font


### PR DESCRIPTION
So you can pass in `Path` and friends.