### PR TITLE
Compile coverage data correctly on Windows

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,7 @@ source = glyphsLib
 source =
     Lib/glyphsLib
     .tox/*/lib/python*/site-packages/glyphsLib
+    .tox/*/lib/site-packages/glyphsLib
     .tox/pypy*/site-packages/glyphsLib
 
 [report]


### PR DESCRIPTION
On Windows, stuff gets installed to e.g. `.tox/py36/lib/site-packages/glyphsLib`.