### PR TITLE
Changing guideline angle handling to reflect change in UFO3 spec

### DIFF
--- a/Lib/glyphsLib/builder/guidelines.py
+++ b/Lib/glyphsLib/builder/guidelines.py
@@ -36,7 +36,6 @@ def to_ufo_guidelines(self, ufo_obj, glyphs_obj):
         new_guideline = {}
         x, y = guideline.position
         angle = guideline.angle
-        angle = (360 - angle) % 360
         if _is_vertical(x, y, angle):
             new_guideline['x'] = x
         elif _is_horizontal(x, y, angle):
@@ -83,7 +82,7 @@ def to_glyphs_guidelines(self, ufo_obj, glyphs_obj):
         new_guideline.name = name
         new_guideline.position = Point(guideline.x or 0, guideline.y or 0)
         if guideline.angle is not None:
-            new_guideline.angle = (360 - guideline.angle) % 360
+            new_guideline.angle = guideline.angle
         elif _is_vertical(guideline.x, guideline.y, None):
             new_guideline.angle = 90
         glyphs_obj.guides.append(new_guideline)

--- a/Lib/glyphsLib/builder/guidelines.py
+++ b/Lib/glyphsLib/builder/guidelines.py
@@ -35,7 +35,7 @@ def to_ufo_guidelines(self, ufo_obj, glyphs_obj):
     for guideline in guidelines:
         new_guideline = {}
         x, y = guideline.position
-        angle = guideline.angle
+        angle = guideline.angle % 360
         if _is_vertical(x, y, angle):
             new_guideline['x'] = x
         elif _is_horizontal(x, y, angle):
@@ -82,7 +82,7 @@ def to_glyphs_guidelines(self, ufo_obj, glyphs_obj):
         new_guideline.name = name
         new_guideline.position = Point(guideline.x or 0, guideline.y or 0)
         if guideline.angle is not None:
-            new_guideline.angle = guideline.angle
+            new_guideline.angle = guideline.angle % 360
         elif _is_vertical(guideline.x, guideline.y, None):
             new_guideline.angle = 90
         glyphs_obj.guides.append(new_guideline)

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -799,15 +799,15 @@ class ToUfosTest(unittest.TestCase):
         """Test that guidelines are set correctly."""
 
         self._run_guideline_test(
-            [{'position': (1, 2), 'angle': 270}],
+            [{'position': (1, 2), 'angle': 90}],
             [{str('x'): 1, str('y'): 2, str('angle'): 90}])
 
     def test_set_guidelines_duplicates(self):
         """Test that duplicate guidelines are accepted."""
 
         self._run_guideline_test(
-            [{'position': (1, 2), 'angle': 270},
-             {'position': (1, 2), 'angle': 270}],
+            [{'position': (1, 2), 'angle': 90},
+             {'position': (1, 2), 'angle': 90}],
             [{str('x'): 1, str('y'): 2, str('angle'): 90},
              {str('x'): 1, str('y'): 2, str('angle'): 90}])
 

--- a/tests/builder/to_glyphs_test.py
+++ b/tests/builder/to_glyphs_test.py
@@ -212,7 +212,7 @@ def test_guidelines():
 
         assert angled.position.x == 10
         assert angled.position.y == 20
-        assert angled.angle == 330
+        assert angled.angle == 30
         assert angled.name == "lc [1,0,0,1] [#lc1]"
 
         assert vertical.position.x == 10


### PR DESCRIPTION
The UFO3 spec has just been changed (https://github.com/unified-font-object/ufo-spec/issues/26) to acknowledge that most people and tools (specifically Glyphs and Robofont) interpret guideline angle to be CCW, despite what the spec originally stated. This provides the necessary fix and also updates appropriate tests.