### PR TITLE
default designspace.filename should use the provided custom 'family_name'

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -205,7 +205,7 @@ class UFOBuilder(_LoggerMixin):
         self.to_designspace_family_user_data()
 
         # append base style shared by all masters to designspace file name
-        base_family = self.font.familyName or 'Unnamed'
+        base_family = self.family_name or 'Unnamed'
         base_style = find_base_style(self.font.masters)
         if base_style:
             base_style = "-" + base_style


### PR DESCRIPTION
This looks like a regression from glyphsLib 2.2.1.

Previously the returned 'designspace_path' from the `glyphsLib.builder_masters` function that was used in fontmake<=1.4 would return a filename that included the custom --family-name (when provided); in glyphsLib 2.3, the designspace.filename is always set to the GSFont.familyName, regardless of whether a custom --family-name option was passed.

This is a problem because fontmake by default uses the same name as the designspace file for the output filename of the generated variable font.

When building one after the other, and to the same variable_ttf output directory, multiple Noto fonts (e.g. NotoSansBengali and NotoSansBengaliUI) which only differ from each other because of that --family-name option (i.e. they share the same .glyphs source, only differ for the --mti-source .plist file to build the opentype features), the result is that the second will the overwrite the first one, as the generated designspace files will overwrite each other, likewise the output variable fonts.

Anyway, it's a regression and this simple patch fixes it. @marekjez86 needs this urgently, so I'm going to merge and cut a bugfix release after that.