### PR TITLE
custom_params: support 'Reencode Glyphs'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fonttools==3.25.0
+fonttools==3.28.0
 defcon==0.5.1
-MutatorMath==2.1.0
+MutatorMath==2.1.1

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -45,8 +45,8 @@ from glyphsLib.builder.constants import (
     UFO2FT_USE_PROD_NAMES_KEY, FONT_CUSTOM_PARAM_PREFIX,
     MASTER_CUSTOM_PARAM_PREFIX)
 
-from classes_test import (generate_minimal_font, generate_instance_from_dict,
-                          add_glyph, add_anchor, add_component)
+from ..classes_test import (generate_minimal_font, generate_instance_from_dict,
+                            add_glyph, add_anchor, add_component)
 
 
 class BuildStyleMapNamesTest(unittest.TestCase):

--- a/tests/builder/roundtrip_test.py
+++ b/tests/builder/roundtrip_test.py
@@ -20,7 +20,7 @@ import os
 import glyphsLib
 from glyphsLib import classes
 
-import test_helpers
+from .. import test_helpers
 
 
 class UFORoundtripTest(unittest.TestCase, test_helpers.AssertUFORoundtrip):

--- a/tests/builder/to_glyphs_test.py
+++ b/tests/builder/to_glyphs_test.py
@@ -27,7 +27,7 @@ from glyphsLib.builder.constants import GLYPHS_COLORS, GLYPHLIB_PREFIX
 from glyphsLib import to_glyphs, to_ufos, to_designspace
 from glyphsLib import classes
 
-from fontTools.designspaceLib import DesignSpaceDocument
+from fontTools.designspaceLib import DesignSpaceDocument, AxisDescriptor
 
 # TODO: (jany) think hard about the ordering and RTL/LTR
 # TODO: (jany) make one generic test with data using pytest
@@ -321,11 +321,20 @@ def test_designspace_source_locations(tmpdir):
     bold_ufo_path = os.path.join(str(tmpdir), 'bold.ufo')
 
     designspace = DesignSpaceDocument()
+    wght = AxisDescriptor()
+    wght.minimum = 100
+    wght.maximum = 700
+    wght.default = 100
+    wght.name = "Weight"
+    wght.tag = "wght"
+    designspace.addAxis(wght)
     light_source = designspace.newSourceDescriptor()
     light_source.filename = 'light.ufo'
+    light_source.location = {"Weight": 100}
     designspace.addSource(light_source)
     bold_source = designspace.newSourceDescriptor()
     bold_source.path = bold_ufo_path
+    bold_source.location = {"Weight": 700}
     designspace.addSource(bold_source)
     designspace.write(designspace_path)
 

--- a/tests/data/DesignspaceGenTestItalic.designspace
+++ b/tests/data/DesignspaceGenTestItalic.designspace
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<designspace format="3">
+<designspace format="4.0">
     <axes>
         <axis default="400" maximum="800" minimum="300" name="Weight" tag="wght" />
     </axes>

--- a/tests/data/DesignspaceGenTestRegular.designspace
+++ b/tests/data/DesignspaceGenTestRegular.designspace
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<designspace format="3">
+<designspace format="4.0">
     <axes>
         <axis default="400" maximum="800" minimum="300" name="Weight" tag="wght" />
     </axes>

--- a/tests/data/DesignspaceTestBasic.designspace
+++ b/tests/data/DesignspaceTestBasic.designspace
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<designspace format="3">
+<designspace format="4.0">
     <axes>
         <axis default="400" maximum="900" minimum="400" name="Weight" tag="wght">
             <map input="400" output="90" />

--- a/tests/data/DesignspaceTestFamilyName.designspace
+++ b/tests/data/DesignspaceTestFamilyName.designspace
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<designspace format="3">
+<designspace format="4.0">
     <axes>
         <axis default="400" maximum="600" minimum="400" name="Weight" tag="wght">
             <map input="400" output="90" />

--- a/tests/data/DesignspaceTestFileName.designspace
+++ b/tests/data/DesignspaceTestFileName.designspace
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<designspace format="3">
+<designspace format="4.0">
     <axes>
         <axis default="400" maximum="600" minimum="400" name="Weight" tag="wght">
             <map input="400" output="90" />

--- a/tests/data/DesignspaceTestInactive.designspace
+++ b/tests/data/DesignspaceTestInactive.designspace
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<designspace format="3">
+<designspace format="4.0">
     <axes>
         <axis default="600" maximum="600" minimum="600" name="Weight" tag="wght">
             <map input="600" output="128" />

--- a/tests/data/DesignspaceTestInstanceOrder.designspace
+++ b/tests/data/DesignspaceTestInstanceOrder.designspace
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<designspace format="3">
+<designspace format="4.0">
     <axes>
         <axis default="400" maximum="900" minimum="400" name="Weight" tag="wght">
             <map input="400" output="90" />

--- a/tests/data/DesignspaceTestTwoAxes.designspace
+++ b/tests/data/DesignspaceTestTwoAxes.designspace
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<designspace format="3">
+<designspace format="4.0">
     <axes>
         <axis default="400" maximum="900" minimum="100" name="Weight" tag="wght">
             <map input="100" output="26" />

--- a/tests/data/TestReencode-Regular.ufo/fontinfo.plist
+++ b/tests/data/TestReencode-Regular.ufo/fontinfo.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<real>800</real>
+	<key>capHeight</key>
+	<real>700</real>
+	<key>copyright</key>
+	<string>Nobody 2019</string>
+	<key>descender</key>
+	<real>-200</real>
+	<key>familyName</key>
+	<string>Test Reencode</string>
+	<key>openTypeHeadCreated</key>
+	<string>2018/06/15 11:22:00</string>
+	<key>openTypeNameDesigner</key>
+	<string>Nobody</string>
+	<key>openTypeOS2WeightClass</key>
+	<integer>400</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Reencode</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>Regular</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>0</integer>
+	<key>xHeight</key>
+	<real>500</real>
+</dict>
+</plist>

--- a/tests/data/TestReencode-Regular.ufo/glyphs/A_.alt.glif
+++ b/tests/data/TestReencode-Regular.ufo/glyphs/A_.alt.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="A.alt" format="2">
+  <advance width="600.0"/>
+  <outline>
+    <contour>
+      <point x="250.0" y="704.0" type="line"/>
+      <point x="-16.0" y="3.0" type="line"/>
+      <point x="94.0" y="-5.0" type="line"/>
+      <point x="191.0" y="298.0" type="line"/>
+      <point x="418.0" y="294.0" type="line"/>
+      <point x="537.0" y="-3.0" type="line"/>
+      <point x="634.0" y="9.0" type="line"/>
+      <point x="363.0" y="699.0" type="line"/>
+    </contour>
+    <contour>
+      <point x="277.0" y="603.0" type="line"/>
+      <point x="338.0" y="603.0" type="line"/>
+      <point x="409.0" y="371.0" type="line"/>
+      <point x="205.0" y="368.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/TestReencode-Regular.ufo/glyphs/A_.glif
+++ b/tests/data/TestReencode-Regular.ufo/glyphs/A_.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="A" format="2">
+  <advance width="600.0"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="250.0" y="704.0" type="line"/>
+      <point x="-6.0" y="3.0" type="line"/>
+      <point x="104.0" y="-5.0" type="line"/>
+      <point x="201.0" y="298.0" type="line"/>
+      <point x="358.0" y="294.0" type="line"/>
+      <point x="477.0" y="-3.0" type="line"/>
+      <point x="574.0" y="9.0" type="line"/>
+      <point x="313.0" y="699.0" type="line"/>
+    </contour>
+    <contour>
+      <point x="267.0" y="573.0" type="line"/>
+      <point x="298.0" y="573.0" type="line"/>
+      <point x="349.0" y="371.0" type="line"/>
+      <point x="215.0" y="368.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/TestReencode-Regular.ufo/glyphs/B_.glif
+++ b/tests/data/TestReencode-Regular.ufo/glyphs/B_.glif
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="B" format="2">
+  <advance width="600.0"/>
+  <unicode hex="0042"/>
+  <outline>
+    <contour>
+      <point x="62.0" y="3.0" type="line"/>
+      <point x="347.0" y="5.0" type="line"/>
+      <point x="456.0" y="5.0"/>
+      <point x="600.0" y="0.0"/>
+      <point x="600.0" y="209.0" type="curve" smooth="yes"/>
+      <point x="600.0" y="387.0"/>
+      <point x="341.0" y="369.0"/>
+      <point x="261.0" y="371.0" type="curve"/>
+      <point x="261.0" y="392.0" type="line"/>
+      <point x="434.0" y="392.0"/>
+      <point x="548.0" y="377.0"/>
+      <point x="548.0" y="555.0" type="curve" smooth="yes"/>
+      <point x="548.0" y="661.0"/>
+      <point x="484.0" y="702.0"/>
+      <point x="348.0" y="702.0" type="curve"/>
+      <point x="65.0" y="702.0" type="line"/>
+    </contour>
+    <contour>
+      <point x="178.0" y="73.0" type="line"/>
+      <point x="159.0" y="325.0" type="line"/>
+      <point x="391.0" y="325.0" type="line" smooth="yes"/>
+      <point x="471.0" y="325.0"/>
+      <point x="512.0" y="276.0"/>
+      <point x="505.0" y="185.0" type="curve" smooth="yes"/>
+      <point x="499.0" y="110.0"/>
+      <point x="457.0" y="72.0"/>
+      <point x="404.0" y="74.0" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="155.0" y="426.0" type="line"/>
+      <point x="166.0" y="653.0" type="line"/>
+      <point x="318.0" y="648.0" type="line"/>
+      <point x="378.0" y="643.0"/>
+      <point x="436.0" y="618.0"/>
+      <point x="436.0" y="561.0" type="curve" smooth="yes"/>
+      <point x="436.0" y="500.0"/>
+      <point x="409.0" y="441.0"/>
+      <point x="319.0" y="433.0" type="curve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/TestReencode-Regular.ufo/glyphs/C_.glif
+++ b/tests/data/TestReencode-Regular.ufo/glyphs/C_.glif
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="C" format="2">
+  <advance width="600.0"/>
+  <unicode hex="0043"/>
+  <outline>
+    <contour>
+      <point x="583.0" y="127.0" type="line"/>
+      <point x="522.0" y="45.0"/>
+      <point x="414.0" y="-7.0"/>
+      <point x="310.0" y="-7.0" type="curve" smooth="yes"/>
+      <point x="124.0" y="-7.0"/>
+      <point x="-26.0" y="157.0"/>
+      <point x="-26.0" y="359.0" type="curve" smooth="yes"/>
+      <point x="-26.0" y="560.0"/>
+      <point x="124.0" y="724.0"/>
+      <point x="310.0" y="724.0" type="curve" smooth="yes"/>
+      <point x="423.0" y="724.0"/>
+      <point x="512.0" y="685.0"/>
+      <point x="583.0" y="601.0" type="curve"/>
+      <point x="512.0" y="544.0" type="line"/>
+      <point x="466.0" y="612.0"/>
+      <point x="395.0" y="655.0"/>
+      <point x="315.0" y="655.0" type="curve" smooth="yes"/>
+      <point x="176.0" y="655.0"/>
+      <point x="63.0" y="523.0"/>
+      <point x="63.0" y="360.0" type="curve" smooth="yes"/>
+      <point x="63.0" y="197.0"/>
+      <point x="176.0" y="65.0"/>
+      <point x="315.0" y="65.0" type="curve" smooth="yes"/>
+      <point x="393.0" y="65.0"/>
+      <point x="463.0" y="107.0"/>
+      <point x="509.0" y="172.0" type="curve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/TestReencode-Regular.ufo/glyphs/D_.glif
+++ b/tests/data/TestReencode-Regular.ufo/glyphs/D_.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="D" format="2">
+  <advance width="600.0"/>
+  <unicode hex="0044"/>
+  <outline>
+    <contour>
+      <point x="273.0" y="3.0" type="line"/>
+      <point x="501.0" y="0.0"/>
+      <point x="591.0" y="133.0"/>
+      <point x="598.0" y="356.0" type="curve" smooth="yes"/>
+      <point x="606.0" y="599.0"/>
+      <point x="481.0" y="709.0"/>
+      <point x="277.0" y="709.0" type="curve"/>
+      <point x="30.0" y="708.0" type="line"/>
+      <point x="33.0" y="716.0"/>
+      <point x="27.0" y="239.0"/>
+      <point x="26.0" y="4.0" type="curve"/>
+    </contour>
+    <contour>
+      <point x="283.0" y="71.0" type="curve"/>
+      <point x="97.0" y="72.0" type="line"/>
+      <point x="98.0" y="248.0"/>
+      <point x="102.0" y="639.0"/>
+      <point x="100.0" y="633.0" type="curve"/>
+      <point x="286.0" y="634.0" type="line"/>
+      <point x="439.0" y="634.0"/>
+      <point x="513.0" y="539.0"/>
+      <point x="507.0" y="356.0" type="curve" smooth="yes"/>
+      <point x="502.0" y="188.0"/>
+      <point x="454.0" y="69.0"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/TestReencode-Regular.ufo/glyphs/contents.plist
+++ b/tests/data/TestReencode-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>A</key>
+	<string>A_.glif</string>
+	<key>A.alt</key>
+	<string>A_.alt.glif</string>
+	<key>B</key>
+	<string>B_.glif</string>
+	<key>C</key>
+	<string>C_.glif</string>
+	<key>D</key>
+	<string>D_.glif</string>
+	<key>space</key>
+	<string>space.glif</string>
+</dict>
+</plist>

--- a/tests/data/TestReencode-Regular.ufo/glyphs/layerinfo.plist
+++ b/tests/data/TestReencode-Regular.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/tests/data/TestReencode-Regular.ufo/glyphs/space.glif
+++ b/tests/data/TestReencode-Regular.ufo/glyphs/space.glif
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="space" format="2">
+  <advance width="600.0"/>
+  <unicode hex="0020"/>
+  <outline>
+  </outline>
+</glyph>

--- a/tests/data/TestReencode-Regular.ufo/layercontents.plist
+++ b/tests/data/TestReencode-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/tests/data/TestReencode-Regular.ufo/metainfo.plist
+++ b/tests/data/TestReencode-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/tests/data/TestReencode.designspace
+++ b/tests/data/TestReencode.designspace
@@ -1,0 +1,78 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="4.0">
+    <axes>
+        <axis default="400" maximum="400" minimum="400" name="Weight" tag="wght">
+            <map input="400" output="100" />
+        </axis>
+    </axes>
+    <sources>
+        <source familyname="Test Reencode" filename="TestReencode-Regular.ufo" name="Test Reencode Regular" stylename="Regular">
+            <lib copy="1" />
+            <groups copy="1" />
+            <features copy="1" />
+            <info copy="1" />
+            <location>
+                <dimension name="Weight" xvalue="100" />
+            </location>
+        </source>
+    </sources>
+    <instances>
+        <instance familyname="Test Reencode" filename="instance_ufo/TestReencode-Regular.ufo" name="Test Reencode Regular" stylemapfamilyname="Test Reencode" stylemapstylename="regular" stylename="Regular">
+            <location>
+                <dimension name="Weight" xvalue="100" />
+            </location>
+            <kerning />
+            <info />
+            <lib>
+                <dict>
+                    <key>com.schriftgestaltung.customParameters</key>
+                    <array>
+                        <array>
+                            <string>Keep Glyphs</string>
+                            <array>
+                                <string>space</string>
+                                <string>A</string>
+                                <string>B</string>
+                                <string>C</string>
+                                <string>D</string>
+                            </array>
+                        </array>
+                    </array>
+                </dict>
+            </lib>
+        </instance>
+        <instance familyname="Test Reencode UI" filename="instance_ufo/TestReencodeUI-Regular.ufo" name="Test Reencode UI Regular" stylemapfamilyname="Test Reencode UI" stylemapstylename="regular" stylename="Regular">
+            <location>
+                <dimension name="Weight" xvalue="100" />
+            </location>
+            <kerning />
+            <info />
+            <lib>
+                <dict>
+                    <key>com.schriftgestaltung.customParameters</key>
+                    <array>
+                        <array>
+                            <string>Keep Glyphs</string>
+                            <array>
+                                <string>space</string>
+                                <string>A.alt</string>
+                                <string>B</string>
+                                <string>C</string>
+                                <string>D</string>
+                            </array>
+                        </array>
+                        <array>
+                            <string>Reencode Glyphs</string>
+                            <array>
+                                <string>A.alt=0041</string>
+                                <string>C=</string>
+                                <string>D=0064</string>
+                                <string>Z=005A</string>
+                            </array>
+                        </array>
+                    </array>
+                </dict>
+            </lib>
+        </instance>
+    </instances>
+</designspace>

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -28,7 +28,7 @@ from glyphsLib.types import parse_datetime, Point, Rect
 from glyphsLib.writer import dump, dumps
 from glyphsLib.parser import Parser
 
-import test_helpers
+from . import test_helpers
 
 
 class WriterTest(unittest.TestCase, test_helpers.AssertLinesEqual):


### PR DESCRIPTION
fixes https://github.com/googlei18n/glyphsLib/issues/205

There is no point in attempting to roundtrip this custom parameter, since it only applies to instances (which are not meant to be convertible back to Glyphs, but only for export).

I'll add a test case later. Just want to check with @belluzj @madig or @moyogo if they think this in the right direction.

It's an issue that affect the UI variant of Noto Sans Bengali, Malayalam and Devanagari. These use a combination of "Reencode Glyphs" and "Keep Glyphs" to deal with some UI glyph variants (more compressed vertically).