### PR TITLE
Make creating background layers optional

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -71,7 +71,8 @@ def build_masters(filename,
                   family_name=None,
                   propagate_anchors=True,
                   minimize_glyphs_diffs=False,
-                  normalize_ufos=False):
+                  normalize_ufos=False,
+                  create_background_layers=False):
     """Write and return UFOs from the masters and the designspace defined in a
     .glyphs file.
 
@@ -105,7 +106,7 @@ def build_masters(filename,
     for source in designspace.sources:
         ufos.append(source.font)
 
-        if minimize_glyphs_diffs:
+        if create_background_layers:
             ufo_create_background_layer_for_all_glyphs(source.font)
 
         ufo_path = os.path.join(master_dir, source.filename)

--- a/Lib/glyphsLib/cli.py
+++ b/Lib/glyphsLib/cli.py
@@ -88,6 +88,15 @@ def main(args=None):
             "differences due to spacing, reordering of keys, etc."
         ),
     )
+    group.add_argument(
+        "--create-background-layers",
+        action="store_true",
+        help=(
+            "Create background layers for all glyphs unless present, "
+            "this can help in a workflow with multiple tools that "
+            "may create background layers automatically."
+        ),
+    )
 
     parser_ufo2glyphs = subparsers.add_parser("ufo2glyphs", help=ufo2glyphs.__doc__)
     parser_ufo2glyphs.set_defaults(func=ufo2glyphs)
@@ -159,6 +168,7 @@ def glyphs2ufo(options):
         minimize_glyphs_diffs=options.no_preserve_glyphsapp_metadata,
         propagate_anchors=options.propagate_anchors,
         normalize_ufos=options.no_normalize_ufos,
+        create_background_layers=options.create_background_layers,
     )
 
 


### PR DESCRIPTION
We use this internally because our Fontlab 5 export script does it. It was originally implemented to reduce Git merge conflicts when people inadvertently created background layers (or masks).