### PR TITLE
Fix glyphsdata updating

### DIFF
--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -83,7 +83,7 @@ def get_glyph(glyph_name, data=glyphdata_generated):
 
     # Lastly, generate the category in the sense of Glyph's
     # GSGlyphInfo.category and .subCategory.
-    category, sub_category = _get_category(base_name, unicode_characters, data)
+    category, sub_category = _get_category(base_name, unicode_characters, data=data)
 
     return Glyph(
         glyph_name, production_name, unicode_characters, category, sub_category

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -106,10 +106,7 @@ def _lookup_production_name(glyph_name, data=glyphdata_generated):
     - Suffix is e.g. "case".
     """
 
-    # The OpenType feature file specification says it's 63, the AGL says it's 31. We
-    # settle on 63. makeotf uses 63 as explained by Read Roberts from Adobe in
-    # https://github.com/fontforge/fontforge/pull/2500#issuecomment-143263393
-    # (Sep 25, 2015).
+    # The AGLFN has been amended to allow a maximum of 63 characters in a glyph name.
     MAX_GLYPH_NAME_LENGTH = 63
 
     def is_unicode_u_value(name):

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -116,11 +116,14 @@ def _lookup_production_name(glyph_name, data=glyphdata_generated):
         return name.startswith("u") and all(
             part_char in "0123456789ABCDEF" for part_char in name[1:]
         )
+    # First, look up the full glyph name in PRODUCTION_NAMES before looking at
+    # the AGL. This is necessary to correctly process glyphs like
+    # "A.blackCircled", which can be "misinterpreted" as a variant glyph and get
+    # looked up in the AGLFN.
+    if glyph_name in data.PRODUCTION_NAMES:  # e.g. ain_alefMaksura-ar.fina -> uniFD13
+        return data.PRODUCTION_NAMES[glyph_name]
 
     base_name, dot, suffix = glyph_name.partition(".")
-
-    # First, look up the full glyph name and base name in the AGLFN and in
-    # PRODUCTION_NAMES.
     if (
         glyph_name in agl.AGL2UV
         or base_name in agl.AGL2UV
@@ -128,8 +131,6 @@ def _lookup_production_name(glyph_name, data=glyphdata_generated):
     ):
         return glyph_name
 
-    if glyph_name in data.PRODUCTION_NAMES:  # e.g. ain_alefMaksura-ar.fina -> uniFD13
-        return data.PRODUCTION_NAMES[glyph_name]
     if base_name in data.PRODUCTION_NAMES:
         final_production_name = data.PRODUCTION_NAMES[base_name] + dot + suffix
         if len(final_production_name) > MAX_GLYPH_NAME_LENGTH:

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -82,8 +82,17 @@ def get_glyph(glyph_name, data=glyphdata_generated):
             unicode_characters = agl.toUnicode(production_name) or None
 
     # Lastly, generate the category in the sense of Glyph's
-    # GSGlyphInfo.category and .subCategory.
-    category, sub_category = _get_category(glyph_name, unicode_characters, data=data)
+    # GSGlyphInfo.category and .subCategory. As some entries have a production name, 
+    # but no Unicode value, we need to generate Unicode characters for the categorizer 
+    # to get the correct result.
+    if production_name:
+        category, sub_category = _get_category(
+            glyph_name, agl.toUnicode(production_name), data=data
+        )
+    else:
+        category, sub_category = _get_category(
+            glyph_name, unicode_characters, data=data
+        )
 
     return Glyph(
         glyph_name, production_name, unicode_characters, category, sub_category

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -76,8 +76,8 @@ def get_glyph(glyph_name, data=glyphdata_generated):
     #    could be derived.
     # 2. For some others, Glyphs has a different idea than the agl module.
     unicode_characters = None
-    if base_name not in data.MISSING_UNICODE_STRINGS:  # 1.
-        unicode_characters = data.IRREGULAR_UNICODE_STRINGS.get(base_name)  # 2.
+    if glyph_name not in data.MISSING_UNICODE_STRINGS:  # 1.
+        unicode_characters = data.IRREGULAR_UNICODE_STRINGS.get(glyph_name)  # 2.
         if unicode_characters is None:
             unicode_characters = agl.toUnicode(production_name) or None
 

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -52,7 +52,7 @@ def get_glyph(glyph_name, data=glyphdata_generated):
     # (e.g. "A-cy" -> "uni0410") so that e.g. PDF readers can map from names
     # to Unicode values. FontTool's agl module can turn this into the actual
     # character.
-    production_name = _lookup_production_name(glyph_name)
+    production_name = _lookup_production_name(glyph_name, data=data)
 
     # Some Glyphs files use production names instead of Glyph's "nice names".
     # We catch this here, so that we can return the same properties as if

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -244,7 +244,7 @@ def _get_category(glyph_name, character, data=glyphdata_generated):
     # More exceptions.
     if glyph_name.endswith("-ko"):
         return ("Letter", "Syllable")
-    if glyph_name.endswith("-ethiopic") or glyph_name.endswith("-tifi"):
+    if glyph_name.endswith(("-ethiopic", "-tifi", "-kannada")):
         return ("Letter", None)
     if glyph_name.startswith("box"):
         return ("Symbol", "Geometry")

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -83,7 +83,7 @@ def get_glyph(glyph_name, data=glyphdata_generated):
 
     # Lastly, generate the category in the sense of Glyph's
     # GSGlyphInfo.category and .subCategory.
-    category, sub_category = _get_category(base_name, unicode_characters, data=data)
+    category, sub_category = _get_category(glyph_name, unicode_characters, data=data)
 
     return Glyph(
         glyph_name, production_name, unicode_characters, category, sub_category

--- a/Lib/glyphsLib/glyphdata.py
+++ b/Lib/glyphsLib/glyphdata.py
@@ -90,6 +90,12 @@ def get_glyph(glyph_name, data=glyphdata_generated):
     )
 
 
+def _is_unicode_u_value(name):
+    return name.startswith("u") and all(
+        part_char in "0123456789ABCDEF" for part_char in name[1:]
+    )
+
+
 def _lookup_production_name(glyph_name, data=glyphdata_generated):
     """Return the production name for a glyph name from the GlyphsData.xml
     database according to the AGL specification.
@@ -109,10 +115,6 @@ def _lookup_production_name(glyph_name, data=glyphdata_generated):
     # The AGLFN has been amended to allow a maximum of 63 characters in a glyph name.
     MAX_GLYPH_NAME_LENGTH = 63
 
-    def is_unicode_u_value(name):
-        return name.startswith("u") and all(
-            part_char in "0123456789ABCDEF" for part_char in name[1:]
-        )
     # First, look up the full glyph name in PRODUCTION_NAMES before looking at
     # the AGL. This is necessary to correctly process glyphs like
     # "A.blackCircled", which can be "misinterpreted" as a variant glyph and get
@@ -162,7 +164,7 @@ def _lookup_production_name(glyph_name, data=glyphdata_generated):
 
                 # Note if there are any characters outside the Unicode BMP, e.g.
                 # "u10FFF" or "u10FFFF". Do not catch e.g. "u013B" though.
-                if len(part_production_name) > 5 and is_unicode_u_value(
+                if len(part_production_name) > 5 and _is_unicode_u_value(
                     part_production_name
                 ):
                     _character_outside_BMP = True
@@ -189,7 +191,7 @@ def _lookup_production_name(glyph_name, data=glyphdata_generated):
         for part in production_names:
             if part.startswith("uni"):
                 uni_names.append(part[3:])
-            elif len(part) == 5 and is_unicode_u_value(part):
+            elif len(part) == 5 and _is_unicode_u_value(part):
                 uni_names.append(part[1:])
             elif part in agl.AGL2UV:
                 uni_names.append("{:04X}".format(agl.AGL2UV[part]))

--- a/MetaTools/generate_glyphdata.py
+++ b/MetaTools/generate_glyphdata.py
@@ -134,6 +134,7 @@ def build_categories(glyphs):
     for key, value in counts.items():
         cat, _count = value.most_common(1)[0]
         default_categories[key] = cat
+    default_categories[None] = ("Letter", None)
 
     # Find irregular categories. Whether it makes much sense for
     # Glyphs.app to disagree with Unicode about Unicode categories,

--- a/tests/glyphdata_test.py
+++ b/tests/glyphdata_test.py
@@ -96,6 +96,11 @@ class GlyphDataTest(unittest.TestCase):
         self.assertEqual(cat("brevecomb.case"), ("Mark", "Nonspacing"))
         self.assertEqual(cat("brevecomb_acutecomb"), ("Mark", "Nonspacing"))
         self.assertEqual(cat("brevecomb_acutecomb.case"), ("Mark", "Nonspacing"))
+        self.assertEqual(cat("yen-bamum.phaseD"), ("Letter", None))
+        self.assertEqual(cat("two_one.circled"), ("Number", "Decimal Digit"))
+        self.assertEqual(cat("tthuu-kannada"), ("Letter", None))
+        self.assertEqual(cat("rakar-deva"), ("Mark", "Nonspacing"))
+        self.assertEqual(cat("ttha-kannada.below"), ("Mark", "Nonspacing"))
 
     def test_bug232(self):
         # https://github.com/googlei18n/glyphsLib/issues/232

--- a/tests/glyphdata_test.py
+++ b/tests/glyphdata_test.py
@@ -58,6 +58,7 @@ class GlyphDataTest(unittest.TestCase):
         self.assertEqual(prod("a_a_dieresiscomb"), "uni006100610308")
         self.assertEqual(prod("brevecomb_acutecomb"), "uni03060301")
         self.assertEqual(prod("vaphalaa-malayalam"), "uni0D030D35.1")
+        self.assertEqual(prod("A.blackCircled"), "u1F150")
 
     def test_unicode(self):
         uni = lambda n: get_glyph(n).unicode


### PR DESCRIPTION
#402.

Still some failures: [glyphdata-fail.txt](https://github.com/googlei18n/glyphsLib/files/2308156/glyphdata-fail.txt)

What to do about Unicode mismatches? We come up with a Unicode string whereas GlyphsData.xml seems to specify only a single Unicode point for a glyph or None?