### PR TITLE
fix glyph's single unicode should be parsed as string, but integer

### DIFF
--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -31,7 +31,7 @@ class Parser(object):
     """Parses Python dictionaries from Glyphs source files."""
 
     value_re = r'(".*?(?<!\\)"|[-_./$A-Za-z0-9]+)'
-    unicode_list_re = re.compile(r'\s*([0-9a-fA-F]+(,[0-9a-fA-F]+)+)')
+    unicode_list_re = re.compile(r'\s*([0-9a-fA-F]+(,[0-9a-fA-F]+)*)')
     start_dict_re = re.compile(r'\s*{')
     end_dict_re = re.compile(r'\s*}')
     dict_delim_re = re.compile(r'\s*;')
@@ -105,7 +105,7 @@ class Parser(object):
                 parsed = m.group(0)
                 i += len(parsed)
                 unicode_list = m.group(1).split(",")
-                return unicode_list, i
+                return len(unicode_list)==1 and unicode_list[0] or unicode_list, i
 
         m = self.value_re.match(text, i)
         if m:

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -101,6 +101,12 @@ class ParserTest(unittest.TestCase):
             [('unicode', ["0000", "0008", "001D"])]
         )
 
+    def test_parse_single_unicodes(self):
+        self.run_test(
+            b'{unicode = 0008;}',
+            [('unicode', "0008")]
+        )
+
     def test_parse_str_nan(self):
         self.run_test(
             b'{mystr = nan;}',


### PR DESCRIPTION
'{unicode = 0008;}'

 is parsed to:

            [('unicode', 8)]

but should be:

            [('unicode', '0008')]
