### PR TITLE
Cache pip packages and pre-commit installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ matrix:
     - python: 2.7
     - python: 3.6
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cache/pre-commit
+
 install: pip install tox-travis
 
 script:


### PR DESCRIPTION
This hopefully cuts down on the awfully long setup time of pre-commit on each commit.