### PR TITLE
set custom 'append' mode for ufo2ft KernFeatureWriter 

### DIFF
--- a/Lib/glyphsLib/builder/constants.py
+++ b/Lib/glyphsLib/builder/constants.py
@@ -81,3 +81,21 @@ CODEPAGE_RANGES = {
 }
 
 REVERSE_CODEPAGE_RANGES = {value: key for key, value in CODEPAGE_RANGES.items()}
+
+UFO2FT_FEATURE_WRITERS_KEY = "com.github.googlei18n.ufo2ft.featureWriters"
+
+# ufo2ft KernFeatureWriter default to "skip" mode (i.e. do not write features
+# if they are already present), while Glyphs.app always adds its automatic
+# kerning to any user written kern lookups. So we need to pass custom "append"
+# mode for the ufo2ft KernFeatureWriter whenever the GSFont contain a non-automatic
+# 'kern' feature.
+# See https://glyphsapp.com/tutorials/contextual-kerning
+# NOTE: Even though we use the default "skip" mode for the MarkFeatureWriter,
+# we still must include it this custom featureWriters list, as this is used
+# instead of the default ufo2ft list of feature writers.
+# This also means that if ufo2ft adds new writers to that default list, we
+# would need to update this accordingly... :-/
+DEFAULT_FEATURE_WRITERS = [
+    {"class": "KernFeatureWriter", "options": {"mode": "append"}},
+    {"class": "MarkFeatureWriter", "options": {"mode": "skip"}},
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,7 @@ python_classes =
 addopts =
 	-v
 	-r a
+filterwarnings =
+	default::DeprecationWarning
+	default::PendingDeprecationWarning
+	ignore:The 'path':DeprecationWarning:.*defcon.*

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ commands =
     python -c 'print(r"hint: run {envdir}/bin/pre-commit or {envdir}/Scripts/pre-commit install to add checks as pre-commit hook")'
 
 [testenv:htmlcov]
-basepython = python3.6
 deps =
     coverage
 skip_install = true


### PR DESCRIPTION
ufo2ft users did not like that I changed the default mode for the KernFeatureWriter to match Glyphs.app's behavior. It used to be "skip" (only add feature if not already present), but in ufo2ft v2 I changed it to "append" (add new kern lookups to existing kern feature). The idea was to support this use case:
https://glyphsapp.com/tutorials/contextual-kerning

I decided to revert the kernFeautureWriter default back to "skip". But we need to a way from glyphsLib to signal that, when building fonts from .glyphs sources with fontmake, we still wish to have the ufo2ft-generated kern feature appended to manually written kern lookups.

The solution is to store this custom glyphsLib-specific settings in the designspace lib, and have fontmake apply them when calling ufo2ft.

So, in sum, no changes for fontmake users building from .glyphs sources. But a small change to the glyphsLib-exported designspace, only when GSFont has a manually written "kern" feature.