### PR TITLE
Set output directory to "." if script launched in current dir and nothing is specified

### DIFF
--- a/Lib/glyphsLib/cli.py
+++ b/Lib/glyphsLib/cli.py
@@ -158,7 +158,7 @@ def main(args=None):
 def glyphs2ufo(options):
     """Converts a Glyphs.app source file into UFO masters and a designspace file."""
     if options.output_dir is None:
-        options.output_dir = os.path.dirname(options.glyphs_file)
+        options.output_dir = os.path.dirname(options.glyphs_file) or "."
 
     if options.designspace_path is None:
         options.designspace_path = os.path.join(


### PR DESCRIPTION
Prevents crash in https://github.com/googlei18n/glyphsLib/blob/master/Lib/glyphsLib/__init__.py#L112 when glyphs2ufo is launched from same directory as .glyphs file.