### PR TITLE
Fix converting color to glyphs:

### DIFF
--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -16,6 +16,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 import logging
 
 from defcon import Color  # noqa
+from fontTools.misc.py23 import round
 
 import glyphsLib.glyphdata
 from .common import to_ufo_time, from_loose_ufo_time

--- a/tests/builder/to_glyphs_test.py
+++ b/tests/builder/to_glyphs_test.py
@@ -246,8 +246,10 @@ def test_glyph_color():
 
     font = to_glyphs([ufo])
 
-    assert font.glyphs["a"].color == 3
-    assert font.glyphs["b"].color == [4, 128, 0, 255]
+    rt_a_color = font.glyphs["a"].color
+    assert rt_a_color == 3 and type(rt_a_color) is int
+    rt_b_color = font.glyphs["b"].color
+    assert rt_b_color == [4, 128, 0, 255] and all(type(x) is int for x in rt_b_color)
 
     ufo, = to_ufos(font)
 


### PR DESCRIPTION
Python 2's round() returns a float and 3 returns an int. Use fontTools' round() and int() the result.

Fixes https://github.com/googlei18n/glyphsLib/issues/455.