### PR TITLE
Uniquify master IDs automatically

### DIFF
--- a/Lib/glyphsLib/builder/masters.py
+++ b/Lib/glyphsLib/builder/masters.py
@@ -84,20 +84,12 @@ def to_ufo_master_attributes(self, source, master):
 
 def to_glyphs_master_attributes(self, source, master):
     ufo = source.font
-    try:
-        master.id = ufo.lib[MASTER_ID_LIB_KEY]
-    except KeyError:
-        # GSFontMaster has a random id by default
-        pass
 
-    if master.id.lower() in (m.id.lower() for m in self.font.masters):
-        raise ValueError(
-            "{} contains a '{}' lib key with the duplicate value '{}'. All given "
-            "masters must have a unique ID or data will get corrupted. Please "
-            "check for this lib key and either remove it (will be regenerated) or "
-            "change the value. If there is no key, you just witnessed something "
-            "unlikely.".format(ufo.path, MASTER_ID_LIB_KEY, master.id)
-        )
+    # Glyphs ensures that the master ID is unique by simply making up a new one when
+    # finding a duplicate.
+    ufo_master_id_lib_key = ufo.lib.get(MASTER_ID_LIB_KEY)
+    if ufo_master_id_lib_key and not self.font.masters[ufo_master_id_lib_key]:
+        master.id = ufo_master_id_lib_key
 
     if source.filename is not None and self.minimize_ufo_diffs:
         master.userData[UFO_FILENAME_KEY] = source.filename

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -498,6 +498,7 @@ class FontFontMasterProxy(Proxy):
                 Key = self.__len__() + Key
             return self.values()[Key]
         elif isString(Key):
+            # UUIDs are case-sensitive in Glyphs.app.
             for master in self.values():
                 if master.id == Key:
                     return master
@@ -534,7 +535,9 @@ class FontFontMasterProxy(Proxy):
 
     def append(self, FontMaster):
         FontMaster.font = self._owner
-        if not FontMaster.id:
+        # If the master to be appended has no ID yet or it's a duplicate,
+        # make up a new one.
+        if not FontMaster.id or self[FontMaster.id]:
             FontMaster.id = str(uuid.uuid4()).upper()
         self._owner._masters.append(FontMaster)
 
@@ -1397,7 +1400,7 @@ class GSFontMaster(GSBase):
 
     def __init__(self):
         super(GSFontMaster, self).__init__()
-        self.id = str(uuid.uuid4())
+        self.id = str(uuid.uuid4()).upper()
         self.font = None
         self._name = None
         self._customParameters = []

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -964,12 +964,12 @@ class ToUfosTest(unittest.TestCase):
         except Exception as e:
             self.fail("Unexpected exception: " + str(e))
 
-        ufos[1].lib["com.schriftgestaltung.fontMasterID"] = (
-            ufos[0].lib["com.schriftgestaltung.fontMasterID"].lower()
-        )
+        ufos[1].lib["com.schriftgestaltung.fontMasterID"] = ufos[0].lib[
+            "com.schriftgestaltung.fontMasterID"
+        ]
 
-        with self.assertRaises(ValueError):
-            to_glyphs(ufos)
+        font_rt = to_glyphs(ufos)
+        assert len({m.id for m in font_rt.masters}) == 2
 
 
 class _PointDataPen(object):

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -139,6 +139,18 @@ class GlyphLayersTest(unittest.TestCase):
         layer = glyph.layers["XYZ123"]
         self.assertIsNone(layer)
 
+    def test_append_layer_same_id(self):
+        font = generate_minimal_font()
+        font.masters[0].id = "abc"
+        master2 = GSFontMaster()
+        master2.ascender = 0
+        master2.capHeight = 0
+        master2.descender = 0
+        master2.xHeight = 0
+        master2.id = "abc"
+        font.masters.append(master2)
+        assert len({m.id for m in font.masters}) == 2
+
 
 class GSFontTest(unittest.TestCase):
     def test_init(self):


### PR DESCRIPTION
Instead of crashing when finding duplicate master IDs, simply generate new ones.

Closes https://github.com/googlei18n/glyphsLib/pull/444.