### PR TITLE
to_ufo_master_user_data: do not modify data paths

### DIFF
--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -66,11 +66,10 @@ def to_ufo_master_user_data(self, ufo, master):
         if _user_data_has_no_special_meaning(key):
             ufo.lib[key] = master.userData[key]
 
-    # Restore UFO data files
+    # Restore UFO data files. This code assumes that all paths are POSIX paths.
     if UFO_DATA_KEY in master.userData:
         for filename, data in master.userData[UFO_DATA_KEY].items():
-            os_filename = os.path.join(*filename.split("/"))
-            ufo.data[os_filename] = bytes(data)
+            ufo.data[filename] = bytes(data)
 
 
 def to_ufo_glyph_user_data(self, ufo, glyph):

--- a/tests/builder/lib_and_user_data_test.py
+++ b/tests/builder/lib_and_user_data_test.py
@@ -153,7 +153,7 @@ def test_ufo_lib_equivalent_to_font_master_user_data():
 
 
 def test_ufo_data_into_font_master_user_data(tmpdir):
-    filename = os.path.join("org.customTool", "ufoData.bin")
+    filename = "org.customTool/ufoData.bin"
     data = b"\x00\x01\xFF"
     ufo = defcon.Font()
     ufo.data[filename] = data


### PR DESCRIPTION
fontTools.ufoLib uses the fs module as a data backend, which expects POSIX paths exclusively.

Fixes https://github.com/googlei18n/glyphsLib/issues/464.