### PR TITLE
Switch XML tests from flat comparison to xmldiff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ wheel = ["wheel"] if needs_wheel else []
 with open("README.rst", "r") as f:
     long_description = f.read()
 
-test_requires = ["pytest>=2.8", "ufoNormalizer>=0.3.2"]
+test_requires = ["pytest>=2.8", "ufoNormalizer>=0.3.2", "xmldiff>=2.2"]
 if sys.version_info < (3, 3):
     test_requires.append("mock>=2.0.0")
 

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import print_function, division, absolute_import, unicode_literals
 import os
+from xmldiff import main, formatting
 
 import pytest
 import defcon
@@ -54,16 +55,15 @@ def test_designspace_generation_regular_same_family_name(tmpdir):
 
     path = os.path.join(str(tmpdir), "actual.designspace")
     designspace.write(path)
-    with open(path) as fp:
-        actual = fp.read()
 
     expected_path = os.path.join(
         os.path.dirname(__file__), "..", "data", "DesignspaceGenTestRegular.designspace"
     )
-    with open(expected_path) as fp:
-        expected = fp.read()
 
-    assert expected == actual
+    assert (
+        len(main.diff_files(path, expected_path, formatter=formatting.DiffFormatter()))
+        == 0
+    )
 
 
 def test_designspace_generation_italic_same_family_name(tmpdir):
@@ -102,16 +102,15 @@ def test_designspace_generation_italic_same_family_name(tmpdir):
 
     path = os.path.join(str(tmpdir), "actual.designspace")
     designspace.write(path)
-    with open(path) as fp:
-        actual = fp.read()
 
     expected_path = os.path.join(
         os.path.dirname(__file__), "..", "data", "DesignspaceGenTestItalic.designspace"
     )
-    with open(expected_path) as fp:
-        expected = fp.read()
 
-    assert expected == actual
+    assert (
+        len(main.diff_files(path, expected_path, formatter=formatting.DiffFormatter()))
+        == 0
+    )
 
 
 def test_designspace_generation_regular_different_family_names(tmpdir):

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     coverage
     ufonormalizer
+    xmldiff
     py27: mock>=2.0.0
     -rrequirements.txt
 commands =


### PR DESCRIPTION
This is a proposed solution for #475, which might hopefully remove the need to continually updating test data and abandoning lightly-aged fonttools releases.