### PR TITLE
Implement generation of brace layers in .designspace files

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -342,9 +342,12 @@ class GlyphsBuilder(_LoggerMixin):
         # Sort UFOS in the original order from the Glyphs file
         sorted_sources = self.to_glyphs_ordered_masters()
 
+        # Convert all full source UFOs to Glyphs masters. Sources with layer names
+        # are assumed to be sparse or "brace" layers and are ignored because Glyphs
+        # considers them to be special layers and will handle them itself.
         self._font = self.glyphs_module.GSFont()
         self._sources = OrderedDict()  # Same as in UFOBuilder
-        for index, source in enumerate(sorted_sources):
+        for index, source in enumerate(s for s in sorted_sources if not s.layerName):
             master = self.glyphs_module.GSFontMaster()
             self.to_glyphs_font_attributes(source, master, is_initial=(index == 0))
             self.to_glyphs_master_attributes(source, master)
@@ -389,7 +392,9 @@ class GlyphsBuilder(_LoggerMixin):
         """
         # TODO: (jany) really make a copy to avoid modifying the original object
         copy = designspace
-        for source in copy.sources:
+        # Load only full UFO masters, sparse or "brace" layer sources are assumed to point
+        # to existing layers within one of the full masters.
+        for source in (s for s in copy.sources if not s.layerName):
             if not hasattr(source, "font") or source.font is None:
                 if source.path:
                     # FIXME: (jany) consider not changing the caller's objects

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -392,7 +392,7 @@ class GlyphsBuilder(_LoggerMixin):
         """
         # TODO: (jany) really make a copy to avoid modifying the original object
         copy = designspace
-        # Load only full UFO masters, sparse or "brace" layer sources are assumed 
+        # Load only full UFO masters, sparse or "brace" layer sources are assumed
         # to point to existing layers within one of the full masters.
         for source in (s for s in copy.sources if not s.layerName):
             if not hasattr(source, "font") or source.font is None:

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -392,8 +392,8 @@ class GlyphsBuilder(_LoggerMixin):
         """
         # TODO: (jany) really make a copy to avoid modifying the original object
         copy = designspace
-        # Load only full UFO masters, sparse or "brace" layer sources are assumed to point
-        # to existing layers within one of the full masters.
+        # Load only full UFO masters, sparse or "brace" layer sources are assumed 
+        # to point to existing layers within one of the full masters.
         for source in (s for s in copy.sources if not s.layerName):
             if not hasattr(source, "font") or source.font is None:
                 if source.path:

--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -228,9 +228,11 @@ def to_glyphs_features(self):
 def _features_are_different_across_ufos(self):
     # FIXME: requires that features are in the same order in all feature files;
     #   the only allowed differences are whitespace
-    reference = self.designspace.sources[0].font.features.text or ""
+    # Construct iterator over full UFOs, layer sources do not have a font object set.
+    full_sources = (s for s in self.designspace.sources if not s.layerName)
+    reference = next(full_sources).font.features.text or ""
     reference = _normalize_whitespace(reference)
-    for source in self.designspace.sources[1:]:
+    for source in full_sources:
         other = _normalize_whitespace(source.font.features.text or "")
         if reference != other:
             return True

--- a/Lib/glyphsLib/builder/font.py
+++ b/Lib/glyphsLib/builder/font.py
@@ -156,5 +156,6 @@ def to_glyphs_ordered_masters(self):
 def _original_master_order(source):
     try:
         return source.font.lib[MASTER_ORDER_LIB_KEY]
-    except KeyError:
+    # Key may not be found or source.font be None if it's a layer source.
+    except (KeyError, AttributeError):
         return 1 << 31

--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -14,9 +14,11 @@
 
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+import collections
 import logging
 import os
 
+import fontTools.designspaceLib
 from glyphsLib.util import build_ufo_path
 
 from .masters import UFO_FILENAME_KEY
@@ -30,6 +32,7 @@ def to_designspace_sources(self):
     regular_master = get_regular_master(self.font)
     for master in self.font.masters:
         _to_designspace_source(self, master, (master is regular_master))
+    _to_designspace_source_layer(self)
 
 
 def _to_designspace_source(self, master, is_regular):
@@ -78,6 +81,88 @@ def _to_designspace_source(self, master, is_regular):
     for axis_def in get_axis_definitions(self.font):
         location[axis_def.name] = axis_def.get_design_loc(master)
     source.location = location
+
+
+def _to_designspace_source_layer(self):
+    # To construct a source layer, we need
+    # 1. The Designspace source filename and font object which holds the layer.
+    # 2. The (brace) layer name itself.
+    # 3. The location of the intermediate master in the design space.
+    # (For logging purposes, it's nice to know which glyphs contain the layer.)
+    #
+    # Note that a brace layer can be associated with different master layers (e.g. the
+    # 'a' can have a '{400}' brace layer associated with 'Thin', and 'b''s can be
+    # associte with 'Black').
+    # Also note that if a brace layer name has less values than there are axes, they
+    # are supposed to take on the values from the associated master as the missing
+    # values.
+
+    # First, collect all brace layers in the font and which glyphs and which masters
+    # they belong to.
+    layer_name_to_master_ids = collections.defaultdict(set)
+    layer_name_to_glyph_names = collections.defaultdict(list)
+    for glyph in self.font.glyphs:
+        for layer in glyph.layers:
+            if (
+                "{" in layer.name
+                and "}" in layer.name
+                and ".background" not in layer.name
+            ):
+                layer_name_to_master_ids[layer.name].add(layer.associatedMasterId)
+                layer_name_to_glyph_names[layer.name].append(glyph.name)
+
+    # Next, insert the brace layers in a defined location in the existing designspace.
+    designspace = self._designspace
+    layers_to_insert = collections.defaultdict(list)
+    for layer_name, master_ids in layer_name_to_master_ids.items():
+        # Construct coordinates first...
+        brace_coordinates = [
+            int(c)
+            for c in layer_name[
+                layer_name.index("{") + 1 : layer_name.index("}")
+            ].split(",")
+        ]
+
+        for master_id in master_ids:
+            # ... as they may need to be filled up with the values of the associated
+            # master.
+            master = self._sources[master_id]
+            master_coordinates = brace_coordinates
+            if len(master_coordinates) < len(designspace.axes):
+                master_locations = [master.location[a.name] for a in designspace.axes]
+                master_coordinates = (
+                    brace_coordinates + master_locations[len(brace_coordinates) :]
+                )
+            elif len(master_coordinates) > len(designspace.axes):
+                logger.warning(
+                    "Glyph(s) %s, brace layer '%s' defines more locations than "
+                    "there are design axes.",
+                    layer_name_to_glyph_names[layer_name],
+                    layer_name,
+                )
+
+            # If we have more locations than axes, ignore the extra locations.
+            layer_coordinates_mapping = {
+                axis.name: location
+                for axis, location in zip(designspace.axes, master_coordinates)
+            }
+
+            s = fontTools.designspaceLib.SourceDescriptor()
+            s.filename = master.filename
+            s.font = master.font
+            s.layerName = layer_name
+            s.location = layer_coordinates_mapping
+
+            # We collect all generated SourceDescriptors first, grouped by the masters
+            # they belong to, so we can insert them in a defined order in the next step.
+            layers_to_insert[master_id].append(s)
+
+    # Splice brace layers into the appropriate location after their master.
+    for master_id, brace_layers in layers_to_insert.items():
+        master = self._sources[master_id]
+        insert_index = designspace.sources.index(master) + 1
+        brace_layers.sort(key=lambda x: tuple(x.location.values()))
+        designspace.sources[insert_index:insert_index] = brace_layers
 
 
 def to_glyphs_sources(self):

--- a/Lib/glyphsLib/builder/sources.py
+++ b/Lib/glyphsLib/builder/sources.py
@@ -142,10 +142,10 @@ def _to_designspace_source_layer(self):
                 )
 
             # If we have more locations than axes, ignore the extra locations.
-            layer_coordinates_mapping = {
-                axis.name: location
+            layer_coordinates_mapping = collections.OrderedDict(
+                (axis.name, location)
                 for axis, location in zip(designspace.axes, master_coordinates)
-            }
+            )
 
             s = fontTools.designspaceLib.SourceDescriptor()
             s.filename = master.filename

--- a/tests/builder/roundtrip_test.py
+++ b/tests/builder/roundtrip_test.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import unittest
 import os
 
@@ -37,6 +38,7 @@ class UFORoundtripTest(unittest.TestCase, test_helpers.AssertUFORoundtrip):
             font = glyphsLib.load(f)
         self.assertUFORoundtrip(font)
 
+    @pytest.mark.xfail(reason="Master naming and instance data modification issues.")
     def test_BraceTestFont(self):
         filename = os.path.join(
             os.path.dirname(__file__), "../data/BraceTestFont.glyphs"

--- a/tests/builder/roundtrip_test.py
+++ b/tests/builder/roundtrip_test.py
@@ -37,6 +37,14 @@ class UFORoundtripTest(unittest.TestCase, test_helpers.AssertUFORoundtrip):
             font = glyphsLib.load(f)
         self.assertUFORoundtrip(font)
 
+    def test_BraceTestFont(self):
+        filename = os.path.join(
+            os.path.dirname(__file__), "../data/BraceTestFont.glyphs"
+        )
+        with open(filename) as f:
+            font = glyphsLib.load(f)
+        self.assertUFORoundtrip(font)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import py
+import pytest
+
+
+@pytest.fixture
+def datadir(request):
+    return py.path.local(py.path.local(__file__).dirname).join("data")

--- a/tests/data/BraceTestFont.glyphs
+++ b/tests/data/BraceTestFont.glyphs
@@ -1,0 +1,629 @@
+{
+.appVersion = "1192";
+DisplayStrings = (
+a,
+b
+);
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Width;
+Tag = wdth;
+},
+{
+Name = Weight;
+Tag = wght;
+}
+);
+},
+{
+name = "Disable Last Change";
+value = 1;
+}
+);
+date = "2019-01-09 16:33:47 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
+descender = -200;
+id = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+weight = Light;
+xHeight = 500;
+},
+{
+ascender = 800;
+capHeight = 700;
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 700;
+}
+);
+}
+);
+descender = -200;
+id = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+weight = Bold;
+widthValue = 1000;
+xHeight = 500;
+},
+{
+ascender = 800;
+capHeight = 700;
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 50;
+},
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
+descender = -200;
+iconName = Condensed;
+id = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+weight = Light;
+weightValue = 50;
+width = Condensed;
+xHeight = 500;
+},
+{
+ascender = 800;
+capHeight = 700;
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 50;
+},
+{
+Axis = Weight;
+Location = 700;
+}
+);
+}
+);
+descender = -200;
+id = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+weight = Bold;
+weightValue = 50;
+width = Condensed;
+widthValue = 1000;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = a;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+paths = (
+{
+closed = 1;
+nodes = (
+"504 -22 LINE",
+"504 356 LINE",
+"308 519 LINE",
+"300 522 OFFCURVE",
+"169 442 OFFCURVE",
+"99 403 CURVE",
+"123 316 LINE",
+"300 453 LINE",
+"398 318 LINE",
+"387 -22 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 35 LINE",
+"420 115 LINE",
+"277 35 LINE",
+"101 50 LINE",
+"106 153 LINE",
+"427 161 LINE",
+"430 186 LINE",
+"36 214 LINE",
+"25 -23 LINE",
+"290 -32 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+paths = (
+{
+closed = 1;
+nodes = (
+"504 -22 LINE",
+"504 356 LINE",
+"308 519 LINE",
+"300 522 OFFCURVE",
+"141 464 OFFCURVE",
+"71 425 CURVE",
+"103 301 LINE",
+"258 351 LINE",
+"398 318 LINE",
+"387 -22 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 35 LINE",
+"420 115 LINE",
+"277 35 LINE",
+"181 48 LINE",
+"186 151 LINE",
+"422 129 LINE",
+"436 270 LINE",
+"36 214 LINE",
+"25 -23 LINE",
+"290 -32 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+paths = (
+{
+closed = 1;
+nodes = (
+"252 -22 LINE",
+"252 356 LINE",
+"154 519 LINE",
+"150 522 OFFCURVE",
+"85 442 OFFCURVE",
+"50 403 CURVE",
+"62 316 LINE",
+"135 371 LINE",
+"199 318 LINE",
+"194 -22 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 35 LINE",
+"210 115 LINE",
+"139 35 LINE",
+"51 50 LINE",
+"53 153 LINE",
+"214 161 LINE",
+"215 186 LINE",
+"18 214 LINE",
+"13 -23 LINE",
+"145 -32 LINE"
+);
+}
+);
+width = 300;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+paths = (
+{
+closed = 1;
+nodes = (
+"252 -22 LINE",
+"252 356 LINE",
+"154 519 LINE",
+"150 522 OFFCURVE",
+"71 464 OFFCURVE",
+"36 425 CURVE",
+"52 301 LINE",
+"129 351 LINE",
+"199 318 LINE",
+"194 -22 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 35 LINE",
+"210 115 LINE",
+"139 35 LINE",
+"91 48 LINE",
+"93 151 LINE",
+"211 129 LINE",
+"218 270 LINE",
+"18 214 LINE",
+"13 -23 LINE",
+"145 -32 LINE"
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+layerId = "1ABBBA7E-D0DC-49B1-AC13-AB42C8F97BA5";
+name = "{75}";
+paths = (
+{
+closed = 1;
+nodes = (
+"378 -22 LINE",
+"378 356 LINE",
+"231 519 LINE",
+"225 522 OFFCURVE",
+"127 442 OFFCURVE",
+"74 403 CURVE",
+"92 316 LINE",
+"162 78 LINE",
+"299 318 LINE",
+"290 -22 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"321 35 LINE",
+"315 115 LINE",
+"208 35 LINE",
+"76 50 LINE",
+"80 153 LINE",
+"320 161 LINE",
+"323 186 LINE",
+"27 214 LINE",
+"19 -23 LINE",
+"218 -32 LINE"
+);
+}
+);
+width = 450;
+}
+);
+unicode = 0061;
+},
+{
+glyphname = b;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+paths = (
+{
+closed = 1;
+nodes = (
+"417 148 LINE",
+"417 495 LINE",
+"133 466 LINE",
+"138 143 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+paths = (
+{
+closed = 1;
+nodes = (
+"540 38 LINE",
+"569 554 LINE",
+"95 531 LINE",
+"43 57 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+paths = (
+{
+closed = 1;
+nodes = (
+"209 148 LINE",
+"209 495 LINE",
+"67 466 LINE",
+"69 143 LINE"
+);
+}
+);
+width = 300;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+paths = (
+{
+closed = 1;
+nodes = (
+"270 38 LINE",
+"285 554 LINE",
+"48 531 LINE",
+"22 57 LINE"
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+layerId = "FD486ED6-D76D-490C-B562-C4A027492D0B";
+name = "{75}";
+paths = (
+{
+closed = 1;
+nodes = (
+"405 38 LINE",
+"142 165 LINE",
+"262 592 LINE",
+"33 57 LINE"
+);
+}
+);
+width = 450;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+layerId = "632E4528-00C8-4F10-BDDD-AF6AFE04F5C5";
+name = "Test1 {90, 600}";
+paths = (
+{
+closed = 1;
+nodes = (
+"341 470 LINE",
+"439 112 LINE",
+"341 592 LINE",
+"64 301 LINE"
+);
+}
+);
+width = 585;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+layerId = "B9BEDC92-E24C-4B32-B67C-5E0D08DFC991";
+name = "Test2 {90, 500}";
+paths = (
+{
+closed = 1;
+nodes = (
+"341 470 LINE",
+"439 112 LINE",
+"-240 800 LINE",
+"64 301 LINE"
+);
+}
+);
+width = 585;
+}
+);
+unicode = 0062;
+},
+{
+glyphname = c;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+paths = (
+{
+closed = 1;
+nodes = (
+"302 253 OFFCURVE",
+"332 281 OFFCURVE",
+"332 317 CURVE SMOOTH",
+"332 352 OFFCURVE",
+"302 380 OFFCURVE",
+"264 380 CURVE SMOOTH",
+"226 380 OFFCURVE",
+"196 352 OFFCURVE",
+"196 317 CURVE SMOOTH",
+"196 281 OFFCURVE",
+"226 253 OFFCURVE",
+"264 253 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+paths = (
+{
+closed = 1;
+nodes = (
+"447 28 OFFCURVE",
+"555 131 OFFCURVE",
+"555 258 CURVE SMOOTH",
+"555 384 OFFCURVE",
+"447 487 OFFCURVE",
+"314 487 CURVE SMOOTH",
+"180 487 OFFCURVE",
+"72 384 OFFCURVE",
+"72 258 CURVE SMOOTH",
+"72 131 OFFCURVE",
+"180 28 OFFCURVE",
+"314 28 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+paths = (
+{
+closed = 1;
+nodes = (
+"151 253 OFFCURVE",
+"166 281 OFFCURVE",
+"166 317 CURVE SMOOTH",
+"166 352 OFFCURVE",
+"151 380 OFFCURVE",
+"132 380 CURVE SMOOTH",
+"113 380 OFFCURVE",
+"98 352 OFFCURVE",
+"98 317 CURVE SMOOTH",
+"98 281 OFFCURVE",
+"113 253 OFFCURVE",
+"132 253 CURVE SMOOTH"
+);
+}
+);
+width = 300;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+paths = (
+{
+closed = 1;
+nodes = (
+"224 28 OFFCURVE",
+"278 131 OFFCURVE",
+"278 258 CURVE SMOOTH",
+"278 384 OFFCURVE",
+"224 487 OFFCURVE",
+"157 487 CURVE SMOOTH",
+"90 487 OFFCURVE",
+"36 384 OFFCURVE",
+"36 258 CURVE SMOOTH",
+"36 131 OFFCURVE",
+"90 28 OFFCURVE",
+"157 28 CURVE SMOOTH"
+);
+}
+);
+width = 300;
+}
+);
+unicode = 0063;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+width = 600;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+width = 600;
+}
+);
+unicode = 0020;
+}
+);
+instances = (
+{
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 1;
+};
+name = Thin;
+weightClass = Thin;
+},
+{
+interpolationWidth = 500;
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 0.55556;
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 0.44444;
+};
+name = Regular;
+},
+{
+interpolationWidth = 1000;
+instanceInterpolations = {
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 1;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Bold;
+weightClass = Bold;
+},
+{
+interpolationWeight = 75;
+interpolationWidth = 500;
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 0.27778;
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 0.22222;
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 0.27778;
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 0.22222;
+};
+name = "Semi Consensed";
+widthClass = SemiCondensed;
+},
+{
+interpolationWeight = 50;
+instanceInterpolations = {
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 1;
+};
+name = "Thin Condensed";
+weightClass = Thin;
+widthClass = Condensed;
+},
+{
+interpolationWeight = 50;
+interpolationWidth = 500;
+instanceInterpolations = {
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 0.44444;
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 0.55556;
+};
+name = Condensed;
+widthClass = Condensed;
+},
+{
+interpolationWeight = 50;
+interpolationWidth = 1000;
+instanceInterpolations = {
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 1;
+};
+isBold = 1;
+linkStyle = Condensed;
+name = "Bold Condensed";
+weightClass = Bold;
+widthClass = Condensed;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
This is supposed to work one-way for now (i.e. store brace layers as seperate sources in a .designspace file). Conversion of layer sources not following the brace layer convention when going to .glyphs is something for when the use case arises.