### PR TITLE
Add CLI option to store (or not) editor state

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -90,6 +90,7 @@ def build_masters(
     normalize_ufos=False,
     create_background_layers=False,
     generate_GDEF=True,
+    store_editor_state=True,
 ):
     """Write and return UFOs from the masters and the designspace defined in a
     .glyphs file.
@@ -123,6 +124,7 @@ def build_masters(
         instance_dir=instance_dir,
         minimize_glyphs_diffs=minimize_glyphs_diffs,
         generate_GDEF=generate_GDEF,
+        store_editor_state=store_editor_state,
     )
 
     ufos = []

--- a/Lib/glyphsLib/builder/__init__.py
+++ b/Lib/glyphsLib/builder/__init__.py
@@ -30,6 +30,7 @@ def to_ufos(
     ufo_module=defcon,
     minimize_glyphs_diffs=False,
     generate_GDEF=True,
+    store_editor_state=True,
 ):
     """Take a GSFont object and convert it into one UFO per master.
 
@@ -51,6 +52,7 @@ def to_ufos(
         propagate_anchors=propagate_anchors,
         minimize_glyphs_diffs=minimize_glyphs_diffs,
         generate_GDEF=generate_GDEF,
+        store_editor_state=store_editor_state,
     )
 
     result = list(builder.masters)
@@ -68,6 +70,7 @@ def to_designspace(
     ufo_module=defcon,
     minimize_glyphs_diffs=False,
     generate_GDEF=True,
+    store_editor_state=True,
 ):
     """Take a GSFont object and convert it into a Designspace Document + UFOS.
     The UFOs are available as the attribute `font` of each SourceDescriptor of
@@ -100,6 +103,7 @@ def to_designspace(
         use_designspace=True,
         minimize_glyphs_diffs=minimize_glyphs_diffs,
         generate_GDEF=generate_GDEF,
+        store_editor_state=store_editor_state,
     )
     return builder.designspace
 

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -57,6 +57,7 @@ class UFOBuilder(_LoggerMixin):
         use_designspace=False,
         minimize_glyphs_diffs=False,
         generate_GDEF=True,
+        store_editor_state=True,
     ):
         """Create a builder that goes from Glyphs to UFO + designspace.
 
@@ -79,6 +80,8 @@ class UFOBuilder(_LoggerMixin):
                                  .glyphs files when going glyphs->ufo->glyphs.
         generate_GDEF -- set to False to skip writing a `table GDEF {...}` in
                          the UFO features.
+        store_editor_state -- If True, store editor state in the UFO like which
+                              glyphs are open in which tabs ("DisplayStrings").
         """
         self.font = font
         self.ufo_module = ufo_module
@@ -88,6 +91,7 @@ class UFOBuilder(_LoggerMixin):
         self.use_designspace = use_designspace
         self.minimize_glyphs_diffs = minimize_glyphs_diffs
         self.generate_GDEF = generate_GDEF
+        self.store_editor_state = store_editor_state
 
         # The set of (SourceDescriptor + UFO)s that will be built,
         # indexed by master ID, the same order as masters in the source GSFont.

--- a/Lib/glyphsLib/cli.py
+++ b/Lib/glyphsLib/cli.py
@@ -106,6 +106,14 @@ def main(args=None):
             "may create background layers automatically."
         ),
     )
+    group.add_argument(
+        "--no-store-editor-state",
+        action="store_true",
+        help=(
+            "Skip storing editor state in the UFO, like which glyphs are open "
+            "in which tab (DisplayStrings)."
+        ),
+    )
 
     parser_ufo2glyphs = subparsers.add_parser("ufo2glyphs", help=ufo2glyphs.__doc__)
     parser_ufo2glyphs.set_defaults(func=ufo2glyphs)
@@ -179,6 +187,7 @@ def glyphs2ufo(options):
         normalize_ufos=options.normalize_ufos,
         create_background_layers=options.create_background_layers,
         generate_GDEF=options.generate_GDEF,
+        store_editor_state=not options.no_store_editor_state,
     )
 
 

--- a/tests/builder/roundtrip_test.py
+++ b/tests/builder/roundtrip_test.py
@@ -19,6 +19,7 @@ import unittest
 import os
 
 import glyphsLib
+import glyphsLib.builder.constants
 from glyphsLib import classes
 
 from .. import test_helpers
@@ -46,6 +47,26 @@ class UFORoundtripTest(unittest.TestCase, test_helpers.AssertUFORoundtrip):
         with open(filename) as f:
             font = glyphsLib.load(f)
         self.assertUFORoundtrip(font)
+
+    def test_BraceTestFont_no_editor_state(self):
+        filename = os.path.join(
+            os.path.dirname(__file__), "../data/BraceTestFont.glyphs"
+        )
+        with open(filename) as f:
+            font = glyphsLib.load(f)
+
+        designspace = glyphsLib.to_designspace(font)
+        for source in designspace.sources:
+            assert source.font.lib[
+                glyphsLib.builder.constants.FONT_CUSTOM_PARAM_PREFIX + "DisplayStrings"
+            ] == ["a", "b"]
+
+        designspace = glyphsLib.to_designspace(font, store_editor_state=False)
+        for source in designspace.sources:
+            assert (
+                glyphsLib.builder.constants.FONT_CUSTOM_PARAM_PREFIX + "DisplayStrings"
+                not in source.font.lib
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When working collaboratively, storing editor state is counter-productive and can lead to merge conflicts.