### PR TITLE
designspace_gen_test: Correctly read test files

### DIFF
--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -153,7 +153,8 @@ def test_designspace_generation_same_weight_name(tmpdir):
 
 
 def test_designspace_generation_brace_layers(datadir):
-    font = glyphsLib.loads(str(datadir.join("BraceTestFont.glyphs")))
+    with open(str(datadir.join("BraceTestFont.glyphs"))) as f:
+        font = glyphsLib.load(f)
     designspace = to_designspace(font)
 
     axes_order = [
@@ -187,7 +188,8 @@ def test_designspace_generation_brace_layers(datadir):
 
 
 def test_designspace_generation_instances(datadir):
-    font = glyphsLib.loads(str(datadir.join("BraceTestFont.glyphs")))
+    with open(str(datadir.join("BraceTestFont.glyphs"))) as f:
+        font = glyphsLib.load(f)
     designspace = to_designspace(font)
 
     instances_order = [


### PR DESCRIPTION
Fixes test runs on Windows, where paths tripped up the parser.