### PR TITLE
WIP: Support bracket layers

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -16,7 +16,6 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 from collections import OrderedDict, defaultdict
 import logging
-import itertools
 import os
 from textwrap import dedent
 
@@ -24,7 +23,7 @@ import defcon
 
 from fontTools import designspaceLib
 
-from glyphsLib import classes
+from glyphsLib import classes, util
 from .constants import PUBLIC_PREFIX, FONT_CUSTOM_PARAM_PREFIX, GLYPHLIB_PREFIX
 from .axes import WEIGHT_AXIS_DEF, WIDTH_AXIS_DEF, find_base_style, class_to_value
 
@@ -336,15 +335,9 @@ class UFOBuilder(_LoggerMixin):
                 ufo_glyph.unicodes = []
                 ufo_glyph.lib[GLYPHLIB_PREFIX + "_originalLayerName"] = layer.name
 
-        def pairwise(iterable):
-            "s -> (s0,s1), (s1,s2), (s2, s3), ..."
-            a, b = itertools.tee(iterable)
-            next(b, None)
-            return zip(a, b)
-
         # Generate rules for the bracket layers.
         for glyph_name, axis_crossovers in crossovers.items():
-            for crossover_min, crossover_max in pairwise(
+            for crossover_min, crossover_max in util.pairwise(
                 axis_crossovers + [bracket_axis_max]
             ):
                 rule = designspaceLib.RuleDescriptor()

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -320,6 +320,13 @@ class UFOBuilder(_LoggerMixin):
         # roundtrip stability on Python 2.
         crossovers = defaultdict(list)  # type: Dict[str, List[int]]
         for location, layers in sorted(bracket_layer_map.items()):
+            if not len(layers) % len(list(self.masters)) == 0:
+                raise ValueError(
+                    "Currently, we only support bracket layers that are present on all "
+                    "masters, i.e. what the Glyphs.app tutorial calls 'Changing All "
+                    "Masters'. There is a [{location}] bracket layer missing for a "
+                    "glyph.".format(location=location)
+                )
             glyph_name_set = {l.parent.name for l in layers}
             for glyph_name in glyph_name_set:
                 crossovers[glyph_name].append(location)

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -275,16 +275,18 @@ class UFOBuilder(_LoggerMixin):
                 "Cannot apply bracket layers unless at least one axis is defined."
             )
         bracket_axis = self._designspace.axes[0]
-        # Determine the axis scale in design space (axis.default/minimum/maximum may
-        # be user space).
+
+        # Determine the axis scale in design space because crossovers/locations are
+        # in design space (axis.default/minimum/maximum may be user space).
         if bracket_axis.map:
-            axis_scale = [o for i, o in bracket_axis.map]
+            axis_scale = [design_location for _, design_location in bracket_axis.map]
             bracket_axis_min = min(axis_scale)
             bracket_axis_max = max(axis_scale)
-        else:
+        else:  # No mapping means user and design space are the same.
             bracket_axis_min = bracket_axis.minimum
             bracket_axis_max = bracket_axis.maximum
 
+        # First, organize all bracket layers by crossover value.
         bracket_layer_map = defaultdict(list)  # type: Dict[int, List[classes.GSLayer]]
         for layer in self.bracket_layers:
             n = layer.name.replace(" ", "")
@@ -292,13 +294,14 @@ class UFOBuilder(_LoggerMixin):
                 bracket_crossover = int(n[n.index("[") + 1 : n.index("]")])
             except ValueError:
                 raise ValueError(
-                    "Only bracket layers with one numerical location (meaning the first"
-                    " axis in the designspace file) are currently supported."
+                    "Only bracket layers with one numerical (design space) location "
+                    " (meaning the first axis in the designspace file) are currently "
+                    "supported."
                 )
             if not bracket_axis_min <= bracket_crossover <= bracket_axis_max:
                 raise ValueError(
                     "Glyph {glyph_name}: Bracket layer {layer_name} must be within the "
-                    "bounds of the {bracket_axis_name} axis: minimum "
+                    "design space bounds of the {bracket_axis_name} axis: minimum "
                     "{bracket_axis_minimum}, maximum {bracket_axis_maximum}.".format(
                         glyph_name=layer.parent.name,
                         layer_name=layer.name,
@@ -313,8 +316,8 @@ class UFOBuilder(_LoggerMixin):
         # layers "[300]" and "[600]", crossovers will be
         # {"x": [300, 600], "y": [300, 600]}. This helps with defining overlaps in the
         # replacment rules below.
-        # Note: sort by location to ensure value list sortedness for roundtrip
-        # stability on Python 2.
+        # Note: sort by location to ensure value list appending sortedness for
+        # roundtrip stability on Python 2.
         crossovers = defaultdict(list)  # type: Dict[str, List[int]]
         for location, layers in sorted(bracket_layer_map.items()):
             glyph_name_set = {l.parent.name for l in layers}
@@ -327,12 +330,12 @@ class UFOBuilder(_LoggerMixin):
                 ufo_font = self._sources[
                     layer.associatedMasterId or layer.layerId
                 ].font.layers.defaultLayer
-                ufo_glyph_name = "{layer_parent_name}.BRACKET.{location}".format(
-                    layer_parent_name=layer.parent.name, location=location
+                ufo_glyph_name = "{glyph_name}.BRACKET.{location}".format(
+                    glyph_name=layer.parent.name, location=location
                 )
                 ufo_glyph = ufo_font.newGlyph(ufo_glyph_name)
                 self.to_ufo_glyph(ufo_glyph, layer, layer.parent)
-                ufo_glyph.unicodes = []
+                ufo_glyph.unicodes = []  # Avoid cmap interference
                 ufo_glyph.lib[GLYPHLIB_PREFIX + "_originalLayerName"] = layer.name
 
         # Generate rules for the bracket layers.

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -147,6 +147,7 @@ class UFOBuilder(_LoggerMixin):
         #     on demand.
         self.to_ufo_font_attributes(self.family_name)
 
+        # Generate the main (master) layers first.
         for glyph in self.font.glyphs:
             for layer in glyph.layers.values():
                 if layer.associatedMasterId != layer.layerId:
@@ -160,6 +161,7 @@ class UFOBuilder(_LoggerMixin):
                 ufo_glyph = ufo_layer.newGlyph(glyph.name)
                 self.to_ufo_glyph(ufo_glyph, layer, glyph)
 
+        # And sublayers (brace, bracket, ...) second.
         for glyph, layer in supplementary_layer_data:
             if (
                 layer.layerId not in master_layer_ids
@@ -210,6 +212,7 @@ class UFOBuilder(_LoggerMixin):
         """
         if self._designspace_is_complete:
             return self._designspace
+
         self._designspace_is_complete = True
         list(self.masters)  # Make sure that the UFOs are built
         self.to_designspace_axes()

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -289,7 +289,7 @@ class UFOBuilder(_LoggerMixin):
         # First, organize all bracket layers by crossover value.
         bracket_layer_map = defaultdict(list)  # type: Dict[int, List[classes.GSLayer]]
         for layer in self.bracket_layers:
-            n = layer.name.replace(" ", "")
+            n = layer.name
             try:
                 bracket_crossover = int(n[n.index("[") + 1 : n.index("]")])
             except ValueError:

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -231,7 +231,8 @@ class UFOBuilder(_LoggerMixin):
         self.to_designspace_instances()
         self.to_designspace_family_user_data()
 
-        self._apply_bracket_layers()
+        if self.bracket_layers:
+            self._apply_bracket_layers()
 
         # append base style shared by all masters to designspace file name
         base_family = self.family_name or "Unnamed"
@@ -270,6 +271,10 @@ class UFOBuilder(_LoggerMixin):
         As of Glyphs.app 2.6, only single axis bracket layers are supported, we assume
         the axis to be the first axis in the Designspace.
         """
+        if not self._designspace.axes:
+            raise ValueError(
+                "Cannot apply bracket layers unless at least one axis is defined."
+            )
         bracket_axis = self._designspace.axes[0]
         # Determine the top end of the axis in design space (axis.default may be user
         # space).

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -295,7 +295,7 @@ class UFOBuilder(_LoggerMixin):
             except ValueError:
                 raise ValueError(
                     "Only bracket layers with one numerical (design space) location "
-                    " (meaning the first axis in the designspace file) are currently "
+                    "(meaning the first axis in the designspace file) are currently "
                     "supported."
                 )
             if not bracket_axis_min <= bracket_crossover <= bracket_axis_max:
@@ -343,10 +343,11 @@ class UFOBuilder(_LoggerMixin):
             for crossover_min, crossover_max in util.pairwise(
                 axis_crossovers + [bracket_axis_max]
             ):
-                rule = designspaceLib.RuleDescriptor()
-                rule.name = "{glyph_name}.BRACKET.{crossover_min}".format(
+                glyph_name_substitution = "{glyph_name}.BRACKET.{crossover_min}".format(
                     glyph_name=glyph_name, crossover_min=crossover_min
                 )
+                rule = designspaceLib.RuleDescriptor()
+                rule.name = glyph_name_substitution
                 rule.conditionSets.append(
                     [
                         {
@@ -356,7 +357,7 @@ class UFOBuilder(_LoggerMixin):
                         }
                     ]
                 )
-                rule.subs.append((glyph_name, rule.name))
+                rule.subs.append((glyph_name, glyph_name_substitution))
                 self._designspace.addRule(rule)
 
     # Implementation is split into one file per feature

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -31,12 +31,12 @@ BACKGROUND_WIDTH_KEY = GLYPHLIB_PREFIX + "backgroundWidth"
 
 def to_ufo_glyph(self, ufo_glyph, layer, glyph):
     """Add .glyphs metadata, paths, components, and anchors to a glyph."""
-    from glyphsLib import glyphdata  # Expensive import
-
     ufo_glyph.unicodes = [int(uval, 16) for uval in glyph.unicodes]
+
     note = glyph.note
     if note is not None:
         ufo_glyph.note = note
+
     last_change = glyph.lastChange
     if last_change is not None:
         ufo_glyph.lib[GLYPHLIB_PREFIX + "lastChange"] = to_ufo_time(last_change)
@@ -66,8 +66,9 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph):
     export = glyph.export
     if not export:
         ufo_glyph.lib[GLYPHLIB_PREFIX + "Export"] = export
+
     # FIXME: (jany) next line should be an API of GSGlyph?
-    glyphinfo = glyphdata.get_glyph(ufo_glyph.name)
+    glyphinfo = glyphsLib.glyphdata.get_glyph(ufo_glyph.name)
     production_name = glyph.production or glyphinfo.production_name
     if production_name != ufo_glyph.name:
         postscriptNamesKey = PUBLIC_PREFIX + "postscriptNames"

--- a/Lib/glyphsLib/util.py
+++ b/Lib/glyphsLib/util.py
@@ -15,6 +15,7 @@
 # TODO: (jany) merge with builder/common.py
 
 import logging
+import itertools
 import os
 import shutil
 from fontTools.misc.textTools import num2binary
@@ -102,3 +103,10 @@ def int_list_to_bin(value):
     for i in value:
         result += 1 << i
     return result
+
+
+def pairwise(iterable):
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -248,3 +248,20 @@ def test_designspace_generation_bracket_roundtrip(datadir):
     }
     assert "x.BRACKET.300" not in font_rt.glyphs
     assert "x.BRACKET.600" not in font_rt.glyphs
+
+
+def test_designspace_generation_bracket_roundtrip_unbalanced_brackets(datadir):
+    with open(str(datadir.join("BracketTestFont.glyphs"))) as f:
+        font = glyphsLib.load(f)
+
+    # Delete the "Other [600]" layer to unbalance bracket layers.
+    del font.glyphs["x"].layers["C5C3CA59-C2D0-46F6-B5D3-86541DE36ACB"]
+    with pytest.raises(ValueError) as excinfo:
+        to_designspace(font)
+    assert "bracket layer missing" in str(excinfo)
+
+    # Delete the other [600] layers to rebalance.
+    del font.glyphs["x"].layers["E729A72D-C6FF-4DDD-ADA1-BB5B6FD7E3DD"]
+    del font.glyphs["x"].layers["F5778F4C-2B04-4030-9D7D-09E3C951C089"]
+    del font.glyphs["x"].layers["24328DA8-2CE1-4D0A-9C91-214ED36F6393"]
+    assert to_designspace(font)

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -225,7 +225,9 @@ def test_designspace_generation_bracket_roundtrip(datadir):
 
     for source in designspace.sources:
         assert "[300]" not in source.font.layers
+        assert "Something [300]" not in source.font.layers
         assert "[600]" not in source.font.layers
+        assert "Other [600]" not in source.font.layers
         g1 = source.font["x.BRACKET.300"]
         assert not g1.unicodes
         g2 = source.font["x.BRACKET.600"]
@@ -234,13 +236,15 @@ def test_designspace_generation_bracket_roundtrip(datadir):
     font_rt = to_glyphs(designspace)
     assert "x" in font_rt.glyphs
     g = font_rt.glyphs["x"]
-    assert len(g.layers) == 12 and set(l.name for l in g.layers) == {
+    assert len(g.layers) == 12 and {l.name for l in g.layers} == {
         "[300]",
         "[600]",
         "Bold",
         "Condensed Bold",
         "Condensed Light",
         "Light",
+        "Other [600]",
+        "Something [300]",
     }
     assert "x.BRACKET.300" not in font_rt.glyphs
     assert "x.BRACKET.600" not in font_rt.glyphs

--- a/tests/builder/designspace_gen_test.py
+++ b/tests/builder/designspace_gen_test.py
@@ -204,3 +204,43 @@ def test_designspace_generation_instances(datadir):
         ("New Font Condensed", "regular", {"Width": 50.0, "Weight": 500.0}),
         ("New Font Bold Condensed", "bold", {"Width": 50.0, "Weight": 1000.0}),
     ]
+
+
+def test_designspace_generation_bracket_roundtrip(datadir):
+    with open(str(datadir.join("BracketTestFont.glyphs"))) as f:
+        font = glyphsLib.load(f)
+    designspace = to_designspace(font)
+
+    assert designspace.rules[0].name == "x.BRACKET.300"
+    assert designspace.rules[0].conditionSets == [
+        [dict(name="Weight", minimum=300, maximum=600)]
+    ]
+    assert designspace.rules[0].subs == [("x", "x.BRACKET.300")]
+
+    assert designspace.rules[1].name == "x.BRACKET.600"
+    assert designspace.rules[1].conditionSets == [
+        [dict(name="Weight", minimum=600, maximum=1000)]
+    ]
+    assert designspace.rules[1].subs == [("x", "x.BRACKET.600")]
+
+    for source in designspace.sources:
+        assert "[300]" not in source.font.layers
+        assert "[600]" not in source.font.layers
+        g1 = source.font["x.BRACKET.300"]
+        assert not g1.unicodes
+        g2 = source.font["x.BRACKET.600"]
+        assert not g2.unicodes
+
+    font_rt = to_glyphs(designspace)
+    assert "x" in font_rt.glyphs
+    g = font_rt.glyphs["x"]
+    assert len(g.layers) == 12 and set(l.name for l in g.layers) == {
+        "[300]",
+        "[600]",
+        "Bold",
+        "Condensed Bold",
+        "Condensed Light",
+        "Light",
+    }
+    assert "x.BRACKET.300" not in font_rt.glyphs
+    assert "x.BRACKET.600" not in font_rt.glyphs

--- a/tests/data/BracketTestFont.glyphs
+++ b/tests/data/BracketTestFont.glyphs
@@ -1,0 +1,494 @@
+{
+.appVersion = "1064";
+DisplayStrings = (
+x
+);
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+},
+{
+Name = Width;
+Tag = wdth;
+}
+);
+},
+{
+name = "Disable Last Change";
+value = 1;
+}
+);
+date = "2019-01-09 16:33:47 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
+descender = -200;
+id = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+weight = Light;
+xHeight = 500;
+},
+{
+ascender = 800;
+capHeight = 700;
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 700;
+}
+);
+}
+);
+descender = -200;
+id = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+weight = Bold;
+weightValue = 1000;
+xHeight = 500;
+},
+{
+ascender = 800;
+capHeight = 700;
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 75;
+},
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
+descender = -200;
+id = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+weight = Light;
+width = Condensed;
+widthValue = 50;
+xHeight = 500;
+},
+{
+ascender = 800;
+capHeight = 700;
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 75;
+},
+{
+Axis = Weight;
+Location = 700;
+}
+);
+}
+);
+descender = -200;
+id = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+weight = Bold;
+weightValue = 1000;
+width = Condensed;
+widthValue = 50;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = x;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+paths = (
+{
+closed = 1;
+nodes = (
+"64 0 LINE",
+"88 0 LINE",
+"528 500 LINE",
+"504 500 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+paths = (
+{
+closed = 1;
+nodes = (
+"64 0 LINE",
+"370 0 LINE",
+"528 500 LINE",
+"242 500 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+paths = (
+{
+closed = 1;
+nodes = (
+"32 0 LINE",
+"44 0 LINE",
+"264 500 LINE",
+"252 500 LINE"
+);
+}
+);
+width = 300;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+paths = (
+{
+closed = 1;
+nodes = (
+"32 0 LINE",
+"185 0 LINE",
+"264 500 LINE",
+"121 500 LINE"
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+layerId = "C07DA35D-EBCD-432A-96B9-692C3DD89044";
+name = "[300]";
+paths = (
+{
+closed = 1;
+nodes = (
+"284 0 LINE",
+"308 0 LINE",
+"308 500 LINE",
+"284 500 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"4 242 LINE",
+"602 242 LINE",
+"602 262 LINE",
+"4 262 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+layerId = "24328DA8-2CE1-4D0A-9C91-214ED36F6393";
+name = "[600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"320 226 OFFCURVE",
+"332 238 OFFCURVE",
+"332 252 CURVE SMOOTH",
+"332 266 OFFCURVE",
+"320 278 OFFCURVE",
+"305 278 CURVE SMOOTH",
+"290 278 OFFCURVE",
+"278 266 OFFCURVE",
+"278 252 CURVE SMOOTH",
+"278 238 OFFCURVE",
+"290 226 OFFCURVE",
+"305 226 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+layerId = "55105F32-4D06-4E40-925C-45DE8F220AF9";
+name = "[300]";
+paths = (
+{
+closed = 1;
+nodes = (
+"204 0 LINE",
+"398 0 LINE",
+"398 500 LINE",
+"204 500 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"4 174 LINE",
+"602 174 LINE",
+"602 352 LINE",
+"4 352 LINE"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+layerId = "C5C3CA59-C2D0-46F6-B5D3-86541DE36ACB";
+name = "[600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"439 19 OFFCURVE",
+"547 127 OFFCURVE",
+"547 252 CURVE SMOOTH",
+"547 377 OFFCURVE",
+"439 485 OFFCURVE",
+"305 485 CURVE SMOOTH",
+"171 485 OFFCURVE",
+"63 377 OFFCURVE",
+"63 252 CURVE SMOOTH",
+"63 127 OFFCURVE",
+"171 19 OFFCURVE",
+"305 19 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+associatedMasterId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+layerId = "3B867C64-B59A-4117-AC57-87460CD28220";
+name = "[300]";
+paths = (
+{
+closed = 1;
+nodes = (
+"142 0 LINE",
+"154 0 LINE",
+"154 500 LINE",
+"142 500 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2 242 LINE",
+"301 242 LINE",
+"301 262 LINE",
+"2 262 LINE"
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+layerId = "F5778F4C-2B04-4030-9D7D-09E3C951C089";
+name = "[600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 226 OFFCURVE",
+"166 238 OFFCURVE",
+"166 252 CURVE SMOOTH",
+"166 266 OFFCURVE",
+"160 278 OFFCURVE",
+"153 278 CURVE SMOOTH",
+"145 278 OFFCURVE",
+"139 266 OFFCURVE",
+"139 252 CURVE SMOOTH",
+"139 238 OFFCURVE",
+"145 226 OFFCURVE",
+"153 226 CURVE SMOOTH"
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+layerId = "E5A3E43B-92BC-4747-954F-5A8AFEC587AA";
+name = "[300]";
+paths = (
+{
+closed = 1;
+nodes = (
+"102 0 LINE",
+"199 0 LINE",
+"199 500 LINE",
+"102 500 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2 174 LINE",
+"301 174 LINE",
+"301 352 LINE",
+"2 352 LINE"
+);
+}
+);
+width = 300;
+},
+{
+associatedMasterId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+layerId = "E729A72D-C6FF-4DDD-ADA1-BB5B6FD7E3DD";
+name = "[600]";
+paths = (
+{
+closed = 1;
+nodes = (
+"220 19 OFFCURVE",
+"274 127 OFFCURVE",
+"274 252 CURVE SMOOTH",
+"274 377 OFFCURVE",
+"220 485 OFFCURVE",
+"153 485 CURVE SMOOTH",
+"86 485 OFFCURVE",
+"32 377 OFFCURVE",
+"32 252 CURVE SMOOTH",
+"32 127 OFFCURVE",
+"86 19 OFFCURVE",
+"153 19 CURVE SMOOTH"
+);
+}
+);
+width = 300;
+}
+);
+unicode = 0078;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
+width = 600;
+},
+{
+layerId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
+width = 600;
+},
+{
+layerId = "C402BD76-83A2-4350-9191-E5499E97AF5D";
+width = 600;
+},
+{
+layerId = "7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD";
+width = 600;
+}
+);
+unicode = 0020;
+}
+);
+instances = (
+{
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 1;
+};
+name = Thin;
+weightClass = Thin;
+},
+{
+interpolationWeight = 500;
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 0.55556;
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 0.44444;
+};
+name = Regular;
+},
+{
+interpolationWeight = 1000;
+instanceInterpolations = {
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 1;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Bold;
+weightClass = Bold;
+},
+{
+interpolationWeight = 500;
+interpolationWidth = 75;
+instanceInterpolations = {
+"1034EC4A-9832-4D17-A75A-2B17BF7C4AA6" = 0.27778;
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 0.22222;
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 0.27778;
+"ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1" = 0.22222;
+};
+name = "Semi Consensed";
+widthClass = SemiCondensed;
+},
+{
+interpolationWidth = 50;
+instanceInterpolations = {
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 1;
+};
+name = "Thin Condensed";
+weightClass = Thin;
+widthClass = Condensed;
+},
+{
+interpolationWeight = 500;
+interpolationWidth = 50;
+instanceInterpolations = {
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 0.44444;
+"C402BD76-83A2-4350-9191-E5499E97AF5D" = 0.55556;
+};
+name = Condensed;
+widthClass = Condensed;
+},
+{
+interpolationWeight = 1000;
+interpolationWidth = 50;
+instanceInterpolations = {
+"7C21D6D8-DE5C-402C-AEE1-1C41B2B695CD" = 1;
+};
+isBold = 1;
+linkStyle = Condensed;
+name = "Bold Condensed";
+weightClass = Bold;
+widthClass = Condensed;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/data/BracketTestFont.glyphs
+++ b/tests/data/BracketTestFont.glyphs
@@ -191,7 +191,7 @@ width = 300;
 {
 associatedMasterId = "1034EC4A-9832-4D17-A75A-2B17BF7C4AA6";
 layerId = "C07DA35D-EBCD-432A-96B9-692C3DD89044";
-name = "[300]";
+name = "Something [300]";
 paths = (
 {
 closed = 1;
@@ -268,7 +268,7 @@ width = 600;
 {
 associatedMasterId = "ED9A0AB1-C69E-43FC-AC45-FCA9085EE0B1";
 layerId = "C5C3CA59-C2D0-46F6-B5D3-86541DE36ACB";
-name = "[600]";
+name = "Other [600]";
 paths = (
 {
 closed = 1;


### PR DESCRIPTION
This PR does the following:

- When going from .glyphs to UFO, extract bracket layers into specially named, free-standing glyphs that can be referenced from a .designspace.
- When going back to Glyphs, put the layers back and remove the free-standing glyphs.

Todo:

- [x] Preserve original layer names
- [x] Support Python 2, sigh...
- [ ] ???