### PR TITLE
Roundtrip ufo2ft filters correctly

### DIFF
--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -632,18 +632,19 @@ class FilterParamHandler(AbstractParamHandler):
             glyphs.set_custom_value(glyphs_filter_key, glyphs_filter)
 
     def to_ufo(self, builder, glyphs, ufo):
-        ufo_filters = []
-        for pre_filter in glyphs.get_custom_values("PreFilter"):
-            ufo_filters.append(parse_glyphs_filter(pre_filter, is_pre=True))
-        for filter in glyphs.get_custom_values("Filter"):
-            ufo_filters.append(parse_glyphs_filter(filter, is_pre=False))
+        if not glyphs.is_font():  # Only write filters to the masters
+            ufo_filters = []
+            for pre_filter in glyphs.get_custom_values("PreFilter"):
+                ufo_filters.append(parse_glyphs_filter(pre_filter, is_pre=True))
+            for filter in glyphs.get_custom_values("Filter"):
+                ufo_filters.append(parse_glyphs_filter(filter, is_pre=False))
 
-        if not ufo_filters:
-            return
-        if not ufo.has_lib_key(UFO2FT_FILTERS_KEY):
-            ufo.set_lib_value(UFO2FT_FILTERS_KEY, [])
-        existing = ufo.get_lib_value(UFO2FT_FILTERS_KEY)
-        existing.extend(ufo_filters)
+            if not ufo_filters:
+                return
+            if not ufo.has_lib_key(UFO2FT_FILTERS_KEY):
+                ufo.set_lib_value(UFO2FT_FILTERS_KEY, [])
+            existing = ufo.get_lib_value(UFO2FT_FILTERS_KEY)
+            existing.extend(ufo_filters)
 
 
 register(FilterParamHandler())

--- a/Lib/glyphsLib/builder/custom_params.py
+++ b/Lib/glyphsLib/builder/custom_params.py
@@ -624,8 +624,12 @@ class FilterParamHandler(AbstractParamHandler):
         if ufo_filters is None:
             return
         for ufo_filter in ufo_filters:
-            glyphs_filter, is_pre = write_glyphs_filter(ufo_filter)
-            glyphs.set_custom_values("PreFilter" if is_pre else "Filter", glyphs_filter)
+            glyphs_filter = write_glyphs_filter(ufo_filter)
+            if ufo_filter.get("pre"):
+                glyphs_filter_key = "PreFilter"
+            else:
+                glyphs_filter_key = "Filter"
+            glyphs.set_custom_value(glyphs_filter_key, glyphs_filter)
 
     def to_ufo(self, builder, glyphs, ufo):
         ufo_filters = []

--- a/Lib/glyphsLib/builder/filters.py
+++ b/Lib/glyphsLib/builder/filters.py
@@ -88,4 +88,7 @@ def write_glyphs_filter(result):
         for key, arg in result["kwargs"].items():
             if key.lower() in ("include", "exclude"):
                 elements.append(key + ":" + reverse_cast_to_number_or_bool(arg))
+    for key, arg in result.items():
+        if key.lower() in ("include", "exclude"):
+            elements.append(key + ":" + ",".join(arg))
     return ";".join(elements)

--- a/Lib/glyphsLib/builder/user_data.py
+++ b/Lib/glyphsLib/builder/user_data.py
@@ -22,6 +22,7 @@ from .constants import (
     GLYPHLIB_PREFIX,
     PUBLIC_PREFIX,
     UFO2FT_FEATURE_WRITERS_KEY,
+    UFO2FT_FILTERS_KEY,
     DEFAULT_FEATURE_WRITERS,
 )
 
@@ -174,4 +175,8 @@ def to_glyphs_node_user_data(self, ufo_glyph, node):
 
 
 def _user_data_has_no_special_meaning(key):
-    return not (key.startswith(GLYPHS_PREFIX) or key.startswith(PUBLIC_PREFIX))
+    return not (
+        key.startswith(GLYPHS_PREFIX)
+        or key.startswith(PUBLIC_PREFIX)
+        or key == UFO2FT_FILTERS_KEY
+    )

--- a/tests/builder/custom_params_test.py
+++ b/tests/builder/custom_params_test.py
@@ -32,6 +32,7 @@ from defcon import Font
 from glyphsLib.builder.builders import UFOBuilder
 from glyphsLib.builder.custom_params import _set_default_params
 from glyphsLib.builder.constants import (
+    UFO2FT_FILTERS_KEY,
     UFO2FT_USE_PROD_NAMES_KEY,
     FONT_CUSTOM_PARAM_PREFIX,
     MASTER_CUSTOM_PARAM_PREFIX,
@@ -322,3 +323,20 @@ class SetCustomParamsTest(unittest.TestCase):
         self.font.customParameters["versionString"] = "Version 2.040"
         self.set_custom_params()
         self.assertEqual(self.ufo.info.openTypeNameVersion, "Version 2.040")
+
+    def test_ufo2ft_filter_roundtrip(self):
+        ufo_filters = [
+            {"name": "propagateAnchors", "pre": True, "include": ["a", "b", "c"]}
+        ]
+        glyphs_filter = "propagateAnchors;include:a,b,c"
+
+        self.master.customParameters["PreFilter"] = glyphs_filter
+        self.set_custom_params()
+        self.assertEqual(self.ufo.lib[UFO2FT_FILTERS_KEY], ufo_filters)
+
+        font_rt = glyphsLib.to_glyphs([self.ufo])
+        self.assertEqual(
+            font_rt.masters[0].customParameters["PreFilter"], glyphs_filter
+        )
+        ufo_rt = glyphsLib.to_ufos(font_rt)[0]
+        self.assertEqual(ufo_rt.lib[UFO2FT_FILTERS_KEY], ufo_filters)


### PR DESCRIPTION
Currently, `ufo2glyphs` with a `com.github.googlei18n.ufo2ft.filters` lib key crashes. Fixing the immediate crash shows that in the Glyphs file, you end up getting multiple `PreFilter`s with one letter of the filter name each. The `include` part isn't included. Fixing that shows that the filters are doubled on roundtripping back to UFOs.