### PR TITLE
Integers stay integers

### DIFF
--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -33,6 +33,7 @@ from glyphsLib.types import (
     floatToString,
     readIntlist,
     UnicodesList,
+    parse_float_or_int,
 )
 from glyphsLib.parser import Parser
 from glyphsLib.writer import Writer
@@ -247,13 +248,6 @@ def parse_hint_target(line=None):
         return Point(line)
     else:
         return line
-
-
-def parse_float_or_int(value_string):
-    v = float(value_string)
-    if v.is_integer():
-        return int(v)
-    return v
 
 
 def isString(string):

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -249,6 +249,13 @@ def parse_hint_target(line=None):
         return line
 
 
+def parse_float_or_int(value_string):
+    v = float(value_string)
+    if v.is_integer():
+        return int(v)
+    return v
+
+
 def isString(string):
     return isinstance(string, (str, unicode))
 
@@ -1573,7 +1580,7 @@ class GSNode(GSBase):
 
     def read(self, line):
         m = self._PLIST_VALUE_RE.match(line).groups()
-        self.position = Point(float(m[0]), float(m[1]))
+        self.position = Point(parse_float_or_int(m[0]), parse_float_or_int(m[1]))
         self.type = m[2].lower()
         self.smooth = bool(m[3])
 
@@ -2695,7 +2702,7 @@ class GSLayer(GSBase):
         "vertWidth": float,
         "vertOrigin": float,
         "visible": bool,
-        "width": float,
+        "width": parse_float_or_int,
         "widthMetricsKey": unicode,
     }
     _defaultsForName = {

--- a/Lib/glyphsLib/classes.py
+++ b/Lib/glyphsLib/classes.py
@@ -1280,8 +1280,8 @@ class GSAlignmentZone(GSBase):
     def read(self, src):
         if src is not None:
             p = Point(src)
-            self.position = float(p.value[0])
-            self.size = float(p.value[1])
+            self.position = parse_float_or_int(p.value[0])
+            self.size = parse_float_or_int(p.value[1])
         return self
 
     def __repr__(self):
@@ -1301,7 +1301,7 @@ class GSAlignmentZone(GSBase):
 class GSGuideLine(GSBase):
     _classesForName = {
         "alignment": str,
-        "angle": float,
+        "angle": parse_float_or_int,
         "locked": bool,
         "position": Point,
         "showMeasurement": bool,
@@ -1309,7 +1309,7 @@ class GSGuideLine(GSBase):
         "name": unicode,
     }
     _parent = None
-    _defaultsForName = {"position": Point(0, 0)}
+    _defaultsForName = {"position": Point(0, 0), "angle": 0}
 
     def __init__(self):
         super(GSGuideLine, self).__init__()
@@ -1331,29 +1331,29 @@ MASTER_NAME_WIDTHS = ("Condensed", "SemiCondensed", "Extended", "SemiExtended")
 class GSFontMaster(GSBase):
     _classesForName = {
         "alignmentZones": GSAlignmentZone,
-        "ascender": float,
-        "capHeight": float,
+        "ascender": parse_float_or_int,
+        "capHeight": parse_float_or_int,
         "custom": unicode,
-        "customValue": float,
-        "customValue1": float,
-        "customValue2": float,
-        "customValue3": float,
+        "customValue": parse_float_or_int,
+        "customValue1": parse_float_or_int,
+        "customValue2": parse_float_or_int,
+        "customValue3": parse_float_or_int,
         "customParameters": GSCustomParameter,
-        "descender": float,
+        "descender": parse_float_or_int,
         "guideLines": GSGuideLine,
         "horizontalStems": int,
         "iconName": str,
         "id": str,
-        "italicAngle": float,
+        "italicAngle": parse_float_or_int,
         "name": unicode,
         "userData": dict,
         "verticalStems": int,
         "visible": bool,
         "weight": str,
-        "weightValue": float,
+        "weightValue": parse_float_or_int,
         "width": str,
-        "widthValue": float,
-        "xHeight": float,
+        "widthValue": parse_float_or_int,
+        "xHeight": parse_float_or_int,
     }
     _defaultsForName = {
         # FIXME: (jany) In the latest Glyphs (1113), masters don't have a width
@@ -1361,16 +1361,17 @@ class GSFontMaster(GSBase):
         # still written to the saved files.
         "weight": "Regular",
         "width": "Regular",
-        "weightValue": 100.0,
-        "widthValue": 100.0,
-        "customValue": 0.0,
-        "customValue1": 0.0,
-        "customValue2": 0.0,
-        "customValue3": 0.0,
+        "weightValue": 100,
+        "widthValue": 100,
+        "customValue": 0,
+        "customValue1": 0,
+        "customValue2": 0,
+        "customValue3": 0,
         "xHeight": 500,
         "capHeight": 700,
         "ascender": 800,
         "descender": -200,
+        "italicAngle": 0,
     }
     _wrapperKeysTranslate = {
         "guideLines": "guides",
@@ -1410,11 +1411,11 @@ class GSFontMaster(GSBase):
         self.font = None
         self._name = None
         self._customParameters = []
-        self.italicAngle = 0.0
+        self.italicAngle = 0
         self._userData = None
         self.customName = ""
         for number in ("", "1", "2", "3"):
-            setattr(self, "customValue" + number, 0.0)
+            setattr(self, "customValue" + number, 0)
 
     def __repr__(self):
         return '<GSFontMaster "{}" width {} weight {}>'.format(
@@ -2112,10 +2113,11 @@ class GSSmartComponentAxis(GSBase):
     _classesForName = {
         "name": unicode,
         "bottomName": unicode,
-        "bottomValue": float,
+        "bottomValue": parse_float_or_int,
         "topName": unicode,
-        "topValue": float,
+        "topValue": parse_float_or_int,
     }
+    _defaultsForName = {"bottomValue": 0, "topValue": 0}
     _keyOrder = ("name", "bottomName", "bottomValue", "topName", "topValue")
 
     def shouldWriteValueForKey(self, key):
@@ -2383,18 +2385,18 @@ class GSFeaturePrefix(GSFeature):
 
 class GSAnnotation(GSBase):
     _classesForName = {
-        "angle": float,
+        "angle": parse_float_or_int,
         "position": Point,
         "text": unicode,
         "type": str,
-        "width": float,  # the width of the text field or size of the cicle
+        "width": parse_float_or_int,  # the width of the text field or size of the cicle
     }
     _defaultsForName = {
-        "angle": 0.0,
+        "angle": 0,
         "position": Point(0, 0),
         "text": None,
         "type": 0,
-        "width": 100.0,
+        "width": 100,
     }
     _parent = None
 
@@ -2409,12 +2411,12 @@ class GSInstance(GSBase):
         "active": bool,
         "exports": bool,
         "instanceInterpolations": dict,
-        "interpolationCustom": float,
-        "interpolationCustom1": float,
-        "interpolationCustom2": float,
-        "interpolationCustom3": float,
-        "interpolationWeight": float,
-        "interpolationWidth": float,
+        "interpolationCustom": parse_float_or_int,
+        "interpolationCustom1": parse_float_or_int,
+        "interpolationCustom2": parse_float_or_int,
+        "interpolationCustom3": parse_float_or_int,
+        "interpolationWeight": parse_float_or_int,
+        "interpolationWidth": parse_float_or_int,
         "isBold": bool,
         "isItalic": bool,
         "linkStyle": unicode,
@@ -2426,12 +2428,12 @@ class GSInstance(GSBase):
     _defaultsForName = {
         "active": True,
         "exports": True,
-        "interpolationCustom": 0.0,
-        "interpolationCustom1": 0.0,
-        "interpolationCustom2": 0.0,
-        "interpolationCustom3": 0.0,
-        "interpolationWeight": 100.0,
-        "interpolationWidth": 100.0,
+        "interpolationCustom": 0,
+        "interpolationCustom1": 0,
+        "interpolationCustom2": 0,
+        "interpolationCustom3": 0,
+        "interpolationWeight": 100,
+        "interpolationWidth": 100,
         "weightClass": "Regular",
         "widthClass": "Medium (normal)",
         "instanceInterpolations": {},
@@ -2693,17 +2695,19 @@ class GSLayer(GSBase):
         "paths": GSPath,
         "rightMetricsKey": unicode,
         "userData": dict,
-        "vertWidth": float,
-        "vertOrigin": float,
+        "vertWidth": parse_float_or_int,
+        "vertOrigin": parse_float_or_int,
         "visible": bool,
         "width": parse_float_or_int,
         "widthMetricsKey": unicode,
     }
     _defaultsForName = {
-        "width": 600.0,
+        "width": 600,
         "leftMetricsKey": None,
         "rightMetricsKey": None,
         "widthMetricsKey": None,
+        "vertWidth": 0,
+        "vertOrigin": 0,
     }
     _wrapperKeysTranslate = {"guideLines": "guides", "background": "_background"}
     _keyOrder = (
@@ -2952,7 +2956,7 @@ class GSBackgroundLayer(GSLayer):
     # Reproduce this behaviour here so that the roundtrip does not rely on it.
     @property
     def width(self):
-        return 600.0
+        return 600
 
     @width.setter
     def width(self, whatever):
@@ -3146,7 +3150,7 @@ class GSFont(GSBase):
         "instances": GSInstance,
         "keepAlternatesTogether": bool,
         "kerning": OrderedDict,
-        "keyboardIncrement": float,
+        "keyboardIncrement": parse_float_or_int,
         "manufacturer": unicode,
         "manufacturerURL": unicode,
         "unitsPerEm": int,
@@ -3309,7 +3313,7 @@ class GSFont(GSBase):
         for master_map in kerning.values():
             for glyph_map in master_map.values():
                 for right_glyph, value in glyph_map.items():
-                    glyph_map[right_glyph] = float(value)
+                    glyph_map[right_glyph] = parse_float_or_int(value)
 
     @property
     def selection(self):

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -77,7 +77,9 @@ class Parser(object):
                 v = float(value)
 
                 def current_type(_):
-                    return v if not v.is_integer() else int(v)
+                    if v.is_integer():
+                        return int(v)
+                    return v
 
             except ValueError:
                 current_type = unicode
@@ -110,10 +112,10 @@ class Parser(object):
                 # `plistValue` which handles the escaping itself.
                 value = reader.read(m.group(1))
                 return value, i
-            else:
-                value = self._trim_value(m.group(1))
 
-            if self.current_type is None or self.current_type in (dict, OrderedDict):
+            value = self._trim_value(m.group(1))
+
+            if self.current_type in (None, dict, OrderedDict):
                 self.current_type = self._guess_current_type(parsed, value)
 
             if self.current_type == bool:

--- a/Lib/glyphsLib/parser.py
+++ b/Lib/glyphsLib/parser.py
@@ -29,15 +29,16 @@ logger = logging.getLogger(__name__)
 class Parser(object):
     """Parses Python dictionaries from Glyphs source files."""
 
-    value_re = r'(".*?(?<!\\)"|[-_./$A-Za-z0-9]+)'
+    # FIXME: Why was value_re overwritten? Renamed first one to value_re_shared.
+    value_re_shared = r'(".*?(?<!\\)"|[-_./$A-Za-z0-9]+)'
     start_dict_re = re.compile(r"\s*{")
     end_dict_re = re.compile(r"\s*}")
     dict_delim_re = re.compile(r"\s*;")
     start_list_re = re.compile(r"\s*\(")
     end_list_re = re.compile(r"\s*\)")
     list_delim_re = re.compile(r"\s*,")
-    attr_re = re.compile(r"\s*%s\s*=" % value_re, re.DOTALL)
-    value_re = re.compile(r"\s*%s" % value_re, re.DOTALL)
+    attr_re = re.compile(r"\s*%s\s*=" % value_re_shared, re.DOTALL)
+    value_re = re.compile(r"\s*%s" % value_re_shared, re.DOTALL)
     hex_re = re.compile(r"\s*<([A-Fa-f0-9]+)>", re.DOTALL)
     bytes_re = re.compile(r"\s*<([A-Za-z0-9+/=]+)>", re.DOTALL)
 

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -104,7 +104,7 @@ def Vector(dim):
                 assert len(src) == self.dimension
                 return src
             src = src.replace('"', "")
-            return [float(i) for i in self.regex.match(src).groups()]
+            return [parse_float_or_int(i) for i in self.regex.match(src).groups()]
 
         def plistValue(self):
             assert isinstance(self.value, list) and len(self.value) == self.dimension

--- a/Lib/glyphsLib/types.py
+++ b/Lib/glyphsLib/types.py
@@ -35,7 +35,15 @@ __all__ = [
     "readIntlist",
     "UnicodesList",
     "BinaryData",
+    "parse_float_or_int",
 ]
+
+
+def parse_float_or_int(value_string):
+    v = float(value_string)
+    if v.is_integer():
+        return int(v)
+    return v
 
 
 class ValueType(object):

--- a/tests/classes_test.py
+++ b/tests/classes_test.py
@@ -509,18 +509,18 @@ class GSFontMasterFromFileTest(GSObjectsTestCase):
         # weightValue
         obj = master.weightValue
         old_obj = obj
-        self.assertIsInstance(obj, float)
+        self.assertIsInstance(obj, int)
         master.weightValue = 0.5
         self.assertEqual(master.weightValue, 0.5)
-        obj = old_obj
         self.assertIsInstance(master.weightValue, float)
-        self.assertIsInstance(master.widthValue, float)
-        self.assertIsInstance(master.customValue, float)
-        self.assertIsInstance(master.ascender, float)
-        self.assertIsInstance(master.capHeight, float)
-        self.assertIsInstance(master.xHeight, float)
-        self.assertIsInstance(master.descender, float)
-        self.assertIsInstance(master.italicAngle, float)
+        master.weightValue = old_obj
+        self.assertIsInstance(master.widthValue, int)
+        self.assertIsInstance(master.customValue, int)
+        self.assertIsInstance(master.ascender, int)
+        self.assertIsInstance(master.capHeight, int)
+        self.assertIsInstance(master.xHeight, int)
+        self.assertIsInstance(master.descender, int)
+        self.assertIsInstance(master.italicAngle, int)
         for attr in [
             "weightValue",
             "widthValue",
@@ -532,7 +532,7 @@ class GSFontMasterFromFileTest(GSObjectsTestCase):
             "italicAngle",
         ]:
             value = getattr(master, attr)
-            self.assertIsInstance(value, float)
+            self.assertIsInstance(value, int)
             setattr(master, attr, 0.5)
             self.assertEqual(getattr(master, attr), 0.5)
             setattr(master, attr, value)
@@ -792,7 +792,7 @@ class GSInstanceFromFileTest(GSObjectsTestCase):
         # customValue
         for attr in ["weightValue", "widthValue", "customValue"]:
             value = getattr(instance, attr)
-            self.assertIsInstance(value, float)
+            self.assertIsInstance(value, int)
             setattr(instance, attr, 0.5)
             self.assertEqual(getattr(instance, attr), 0.5)
             setattr(instance, attr, value)

--- a/tests/data/IntegerFloat.glyphs
+++ b/tests/data/IntegerFloat.glyphs
@@ -1,0 +1,46 @@
+{
+.appVersion = "1192";
+DisplayStrings = (
+a
+);
+date = "2019-02-28 21:05:07 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "38FD3B35-3B80-4B99-9E18-F1124E945074";
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = a;
+lastChange = "2019-02-28 21:05:30 +0000";
+layers = (
+{
+layerId = "38FD3B35-3B80-4B99-9E18-F1124E945074";
+paths = (
+{
+closed = 1;
+nodes = (
+"146.0 178 LINE",
+"332.1 180 LINE",
+"329.123456789 253.987654321 OFFCURVE",
+"406 364 OFFCURVE",
+"324 398 CURVE",
+"140 356 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0061;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -17,10 +17,12 @@
 
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+import os
 from collections import OrderedDict
 import unittest
 import datetime
 
+import glyphsLib
 from glyphsLib.parser import Parser
 from glyphsLib.classes import GSGlyph
 
@@ -159,6 +161,26 @@ class ParserGlyphTest(unittest.TestCase):
         self.assertEqual(glyph.leftKerningGroup, "A")
         self.assertEqual(glyph.rightKerningGroup, "A")
         self.assertEqual(glyph.unicode, "0041")
+
+    def test_IntFloatCoordinates(self):
+        filename = os.path.join(os.path.dirname(__file__), "data/IntegerFloat.glyphs")
+        with open(filename) as f:
+            font = glyphsLib.load(f)
+
+        int_points_expected = [
+            (True, True),
+            (False, True),
+            (False, False),
+            (True, True),
+            (True, True),
+            (True, True),
+        ]
+
+        assert isinstance(font.glyphs["a"].layers[0].width, int)
+        assert [
+            (isinstance(n.position.x, int), isinstance(n.position.y, int))
+            for n in font.glyphs["a"].layers[0].paths[0].nodes
+        ] == int_points_expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When round-tripping, integer coordinates in .glyphs files end up being floats in the UFO.

It seems to happen when parsing .glyphs files.