### PR TITLE
Support public.skipExportGlyphs lib key for storing export flags

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -212,6 +212,10 @@ class UFOBuilder(_LoggerMixin):
         self.to_ufo_groups()
         self.to_ufo_kerning()
 
+        # Sanitize skip list and write it to both Designspace- and UFO-level lib keys.
+        # The latter is unnecessary when using e.g. the `ufo2ft.compile*FromDS`
+        # functions, but the data may take a different path. Writing it everywhere can
+        # save on surprises/logic in other software.
         skip_export_glyphs = self._designspace.lib.get("public.skipExportGlyphs")
         if skip_export_glyphs is not None:
             skip_export_glyphs = sorted(set(skip_export_glyphs))
@@ -668,6 +672,10 @@ class GlyphsBuilder(_LoggerMixin):
             source.location = ufo_to_location[ufo]
             designspace.addSource(source)
 
+        # UFO-level skip list lib keys are usually ignored, except when we don't have a
+        # Designspace file to start from. If they exist in the UFOs, promote them to a
+        # Designspace-level lib key. However, to avoid accidents, expect the list to
+        # exist in none or be the same in all UFOs.
         if any("public.skipExportGlyphs" in ufo.lib for ufo in ufos):
             skip_export_glyphs_lists = tuple(
                 tuple(ufo.lib.get("public.skipExportGlyphs", [])) for ufo in ufos

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -677,12 +677,12 @@ class GlyphsBuilder(_LoggerMixin):
         # Designspace-level lib key. However, to avoid accidents, expect the list to
         # exist in none or be the same in all UFOs.
         if any("public.skipExportGlyphs" in ufo.lib for ufo in ufos):
-            skip_export_glyphs_lists = tuple(
-                tuple(ufo.lib.get("public.skipExportGlyphs", [])) for ufo in ufos
+            skip_export_glyphs = set(
+                frozenset(ufo.lib.get("public.skipExportGlyphs", [])) for ufo in ufos
             )
-            if len(set(skip_export_glyphs_lists)) == 1:
+            if len(skip_export_glyphs) == 1:
                 designspace.lib["public.skipExportGlyphs"] = sorted(
-                    set(skip_export_glyphs_lists[0])
+                    next(iter(skip_export_glyphs))
                 )
             else:
                 raise ValueError(

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -208,10 +208,6 @@ class UFOBuilder(_LoggerMixin):
             for layer in ufo.layers:
                 self.to_ufo_layer_lib(layer)
 
-        self.to_ufo_features()  # This depends on the glyphOrder key
-        self.to_ufo_groups()
-        self.to_ufo_kerning()
-
         # Sanitize skip list and write it to both Designspace- and UFO-level lib keys.
         # The latter is unnecessary when using e.g. the `ufo2ft.compile*FromDS`
         # functions, but the data may take a different path. Writing it everywhere can
@@ -222,6 +218,10 @@ class UFOBuilder(_LoggerMixin):
             self._designspace.lib["public.skipExportGlyphs"] = skip_export_glyphs
             for source in self._sources.values():
                 source.font.lib["public.skipExportGlyphs"] = skip_export_glyphs
+
+        self.to_ufo_features()  # This depends on the glyphOrder key
+        self.to_ufo_groups()
+        self.to_ufo_kerning()
 
         for source in self._sources.values():
             yield source.font

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -677,9 +677,9 @@ class GlyphsBuilder(_LoggerMixin):
         # Designspace-level lib key. However, to avoid accidents, expect the list to
         # exist in none or be the same in all UFOs.
         if any("public.skipExportGlyphs" in ufo.lib for ufo in ufos):
-            skip_export_glyphs = set(
+            skip_export_glyphs = {
                 frozenset(ufo.lib.get("public.skipExportGlyphs", [])) for ufo in ufos
-            )
+            }
             if len(skip_export_glyphs) == 1:
                 designspace.lib["public.skipExportGlyphs"] = sorted(
                     next(iter(skip_export_glyphs))

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -201,13 +201,6 @@ class UFOBuilder(_LoggerMixin):
                 ufo_glyph = ufo_layer.newGlyph(glyph.name)
                 self.to_ufo_glyph(ufo_glyph, layer, layer.parent)
 
-        skip_export_glyphs = self._designspace.lib.get("public.skipExportGlyphs")
-        if skip_export_glyphs is not None:
-            skip_export_glyphs = sorted(set(skip_export_glyphs))
-            self._designspace.lib["public.skipExportGlyphs"] = skip_export_glyphs
-            for source in self._sources.values():
-                source.font.lib["public.skipExportGlyphs"] = skip_export_glyphs
-
         for source in self._sources.values():
             ufo = source.font
             if self.propagate_anchors:
@@ -247,6 +240,11 @@ class UFOBuilder(_LoggerMixin):
             base_style = "-" + base_style
         name = (base_family + base_style).replace(" ", "") + ".designspace"
         self.designspace.filename = name
+
+        skip_export_glyphs = self._designspace.lib.get("public.skipExportGlyphs")
+        if skip_export_glyphs is not None:
+            skip_export_glyphs = sorted(set(skip_export_glyphs))
+            self._designspace.lib["public.skipExportGlyphs"] = skip_export_glyphs
 
         return self._designspace
 

--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -201,6 +201,13 @@ class UFOBuilder(_LoggerMixin):
                 ufo_glyph = ufo_layer.newGlyph(glyph.name)
                 self.to_ufo_glyph(ufo_glyph, layer, layer.parent)
 
+        skip_export_glyphs = self._designspace.lib.get("public.skipExportGlyphs")
+        if skip_export_glyphs is not None:
+            skip_export_glyphs = sorted(set(skip_export_glyphs))
+            self._designspace.lib["public.skipExportGlyphs"] = skip_export_glyphs
+            for source in self._sources.values():
+                source.font.lib["public.skipExportGlyphs"] = skip_export_glyphs
+
         for source in self._sources.values():
             ufo = source.font
             if self.propagate_anchors:

--- a/Lib/glyphsLib/builder/features.py
+++ b/Lib/glyphsLib/builder/features.py
@@ -96,7 +96,9 @@ def _to_ufo_features(self, master, ufo):
                 "The features already contain a `table GDEF {...}` statement. "
                 "Either delete it or set generate_GDEF to False."
             )
-        gdef_str = _build_gdef(ufo)
+        gdef_str = _build_gdef(
+            ufo, self._designspace.lib.get("public.skipExportGlyphs")
+        )
 
     # make sure feature text is a unicode string, for defcon
     full_text = (
@@ -105,7 +107,7 @@ def _to_ufo_features(self, master, ufo):
     ufo.features.text = full_text if full_text.strip() else ""
 
 
-def _build_gdef(ufo):
+def _build_gdef(ufo, skipExportGlyphs=None):
     """Build a GDEF table statement (GlyphClassDef and LigatureCaretByPos).
 
     Building GlyphClassDef requires anchor propagation or user care to work as
@@ -132,6 +134,12 @@ def _build_gdef(ufo):
     subCategory_key = GLYPHLIB_PREFIX + "subCategory"
 
     for glyph in ufo:
+        # Do not generate any entries for non-export glyphs, as looking them up on
+        # compilation will fail.
+        if skipExportGlyphs is not None:
+            if glyph.name in skipExportGlyphs:
+                continue
+
         has_attaching_anchor = False
         for anchor in glyph.anchors:
             name = anchor.name

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -158,9 +158,9 @@ def to_glyphs_glyph(self, ufo_glyph, ufo_layer, master):
     if ufo_glyph.markColor:
         glyph.color = _to_glyphs_color(ufo_glyph.markColor)
 
-    # The export flag can be stored in the glyph's lib key or the
-    # Designspace-level public.skipExportGlyphs lib key. The UFO level lib key is
-    # ignored.
+    # The export flag can be stored in the glyph's lib key (for upgrading legacy
+    # sources) or the Designspace-level public.skipExportGlyphs lib key (canonical
+    # place to store the information). The UFO level lib key is ignored.
     if GLYPHLIB_PREFIX + "Export" in ufo_glyph.lib:
         glyph.export = ufo_glyph.lib[GLYPHLIB_PREFIX + "Export"]
     if ufo_glyph.name in self.designspace.lib.get("public.skipExportGlyphs", []):

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -65,7 +65,6 @@ def to_ufo_glyph(self, ufo_glyph, layer, glyph):
 
     export = glyph.export
     if not export:
-        ufo_glyph.lib[GLYPHLIB_PREFIX + "Export"] = export
         if "public.skipExportGlyphs" not in self._designspace.lib:
             self._designspace.lib["public.skipExportGlyphs"] = []
         self._designspace.lib["public.skipExportGlyphs"].append(glyph.name)

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -158,15 +158,12 @@ def to_glyphs_glyph(self, ufo_glyph, ufo_layer, master):
     if ufo_glyph.markColor:
         glyph.color = _to_glyphs_color(ufo_glyph.markColor)
 
-    # The export flag can be stored in the glyph's lib key, the UFO-level
-    # public.skipExportGlyphs lib key or the Designspace-level public.skipExportGlyphs
-    # lib key.
+    # The export flag can be stored in the glyph's lib key or the
+    # Designspace-level public.skipExportGlyphs lib key. The UFO level lib key is
+    # ignored.
     if GLYPHLIB_PREFIX + "Export" in ufo_glyph.lib:
         glyph.export = ufo_glyph.lib[GLYPHLIB_PREFIX + "Export"]
-    if any(
-        ufo_glyph.name in source.font.lib.get("public.skipExportGlyphs", [])
-        for source in self._sources.values()
-    ) or (ufo_glyph.name in self.designspace.lib.get("public.skipExportGlyphs", [])):
+    if ufo_glyph.name in self.designspace.lib.get("public.skipExportGlyphs", []):
         glyph.export = False
 
     ps_names_key = PUBLIC_PREFIX + "postscriptNames"

--- a/Lib/glyphsLib/builder/glyph.py
+++ b/Lib/glyphsLib/builder/glyph.py
@@ -150,9 +150,7 @@ def to_glyphs_glyph(self, ufo_glyph, ufo_layer, master):
 
     if ufo_glyph.unicodes:
         glyph.unicodes = ["{:04X}".format(c) for c in ufo_glyph.unicodes]
-    note = ufo_glyph.note
-    if note is not None:
-        glyph.note = note
+    glyph.note = ufo_glyph.note or ""
     if GLYPHLIB_PREFIX + "lastChange" in ufo_glyph.lib:
         last_change = ufo_glyph.lib[GLYPHLIB_PREFIX + "lastChange"]
         # We cannot be strict about the dateformat because it's not an official
@@ -162,16 +160,14 @@ def to_glyphs_glyph(self, ufo_glyph, ufo_layer, master):
         glyph.color = _to_glyphs_color(ufo_glyph.markColor)
 
     # The export flag can be stored in the glyph's lib key, the UFO-level
-    # public.skipExportGlyphs lib key or the Deisgnspace-level public.skipExportGlyphs
+    # public.skipExportGlyphs lib key or the Designspace-level public.skipExportGlyphs
     # lib key.
     if GLYPHLIB_PREFIX + "Export" in ufo_glyph.lib:
         glyph.export = ufo_glyph.lib[GLYPHLIB_PREFIX + "Export"]
     if any(
-        ufo_glyph.name in source.lib.get("public.skipExportGlyphs", [])
+        ufo_glyph.name in source.font.lib.get("public.skipExportGlyphs", [])
         for source in self._sources.values()
-    ):
-        glyph.export = False
-    if ufo_glyph.name in self.designspace.lib.get("public.skipExportGlyphs", []):
+    ) or (ufo_glyph.name in self.designspace.lib.get("public.skipExportGlyphs", [])):
         glyph.export = False
 
     ps_names_key = PUBLIC_PREFIX + "postscriptNames"

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -887,6 +887,14 @@ class ToUfosTest(unittest.TestCase):
         self.assertEqual(font3.glyphs["c"].export, False)
         self.assertEqual(font3.glyphs["d"].export, True)
 
+        ufos3 = to_ufos(font2)
+        ufo3 = ufos3[0]
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["a"].lib)
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["b"].lib)
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["c"].lib)
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["d"].lib)
+        self.assertEqual(ufo3.lib["public.skipExportGlyphs"], ["a", "c"])
+
     def test_glyph_lib_Export_fake_designspace(self):
         font = generate_minimal_font()
         master = GSFontMaster()

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -842,8 +842,8 @@ class ToUfosTest(unittest.TestCase):
         ds = to_designspace(font)
 
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo["a"].lib)
-        self.assertNotIn("a", ufo.lib.get("public.skipExportGlyphs", []))
-        self.assertNotIn("a", ds.lib.get("public.skipExportGlyphs", []))
+        self.assertNotIn("public.skipExportGlyphs", ufo.lib)
+        self.assertNotIn("public.skipExportGlyphs", ds.lib)
 
         font2 = to_glyphs(ds)
         glyph2 = font2.glyphs[0]
@@ -854,9 +854,9 @@ class ToUfosTest(unittest.TestCase):
         ufo = to_ufos(font2)[0]
         ds = to_designspace(font2)
 
-        self.assertEqual(ufo["a"].lib[GLYPHLIB_PREFIX + "Export"], False)
-        self.assertIn("a", ufo.lib["public.skipExportGlyphs"])
-        self.assertIn("a", ds.lib["public.skipExportGlyphs"])
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo["a"].lib)
+        self.assertNotIn("public.skipExportGlyphs", ufo.lib)
+        self.assertEqual(ds.lib["public.skipExportGlyphs"], ["a"])
 
     def test_glyph_lib_Export_mixed(self):
         font = generate_minimal_font()
@@ -875,11 +875,11 @@ class ToUfosTest(unittest.TestCase):
         ds2 = to_designspace(font2)
         ufo2 = ds2.sources[0].font
 
-        self.assertEqual(ufo2["a"].lib[GLYPHLIB_PREFIX + "Export"], False)
-        self.assertEqual(ufo2["b"].lib[GLYPHLIB_PREFIX + "Export"], False)
-        self.assertEqual(ufo2["c"].lib[GLYPHLIB_PREFIX + "Export"], False)
-        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo["d"].lib)
-        self.assertEqual(ufo2.lib["public.skipExportGlyphs"], ["a", "b", "c"])
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["a"].lib)
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["b"].lib)
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["c"].lib)
+        self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["d"].lib)
+        self.assertNotIn("public.skipExportGlyphs", ufo2.lib)
         self.assertEqual(ds2.lib["public.skipExportGlyphs"], ["a", "b", "c"])
 
         font3 = to_glyphs(ds2)

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -895,6 +895,23 @@ class ToUfosTest(unittest.TestCase):
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["d"].lib)
         self.assertEqual(ufo3.lib["public.skipExportGlyphs"], ["a", "c"])
 
+    def test_glyph_lib_Export_GDEF(self):
+        font = generate_minimal_font()
+        add_glyph(font, "a")
+        add_glyph(font, "d")
+        add_anchor(font, "d", "top", 100, 100)
+
+        ds = to_designspace(font)
+        ufo = ds.sources[0].font
+        self.assertIn(
+            "GlyphClassDef[d]", ufo.features.text.replace("\n", "").replace(" ", "")
+        )
+
+        font.glyphs["d"].export = False
+        ds2 = to_designspace(font)
+        ufo2 = ds2.sources[0].font
+        self.assertEqual(ufo2.features.text, "")
+
     def test_glyph_lib_Export_fake_designspace(self):
         font = generate_minimal_font()
         master = GSFontMaster()

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -841,11 +841,13 @@ class ToUfosTest(unittest.TestCase):
         ufo = to_ufos(font)[0]
 
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo["a"].lib)
+        self.assertNotIn("a", ufo.lib.get("public.skipExportGlyphs", []))
 
         glyph.export = False
         ufo = to_ufos(font)[0]
 
         self.assertEqual(ufo["a"].lib[GLYPHLIB_PREFIX + "Export"], False)
+        self.assertIn("a", ufo.lib["public.skipExportGlyphs"])
 
     def test_glyph_lib_metricsKeys(self):
         font = generate_minimal_font()

--- a/tests/builder/builder_test.py
+++ b/tests/builder/builder_test.py
@@ -835,7 +835,6 @@ class ToUfosTest(unittest.TestCase):
     def test_glyph_lib_Export(self):
         font = generate_minimal_font()
         glyph = add_glyph(font, "a")
-
         self.assertEqual(glyph.export, True)
 
         ufo = to_ufos(font)[0]
@@ -880,11 +879,11 @@ class ToUfosTest(unittest.TestCase):
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["c"].lib)
         self.assertNotIn(GLYPHLIB_PREFIX + "Export", ufo2["d"].lib)
         self.assertNotIn("public.skipExportGlyphs", ufo2.lib)
-        self.assertEqual(ds2.lib["public.skipExportGlyphs"], ["a", "b", "c"])
+        self.assertEqual(ds2.lib["public.skipExportGlyphs"], ["a", "c"])
 
         font3 = to_glyphs(ds2)
         self.assertEqual(font3.glyphs["a"].export, False)
-        self.assertEqual(font3.glyphs["b"].export, False)
+        self.assertEqual(font3.glyphs["b"].export, True)
         self.assertEqual(font3.glyphs["c"].export, False)
         self.assertEqual(font3.glyphs["d"].export, True)
 


### PR DESCRIPTION
https://github.com/googlei18n/glyphsLib/issues/515.

Handling this well in a oh-please-not-more-technical-debt kind of way is tricky.

There are three ways to signal that a glyph should not be exported:
1. The old `com.schriftgestaltung.Glyphs.Export` glyph lib key
2. The new UFO-level `public.skipExportGlyphs` lib key
3. The new Designspace-level `public.skipExportGlyphs` lib key

ufo2ft will look into the Designspace lib key when using the `compile*FromDS` functions and into the UFO-level lib keys with the other `compile*` functions. Writing only to the Designspace-level lib key may complicate e.g. fontmake, which uses `glyphsLib.to_designspace` to convert a .glyphs file into DS + UFOs, but uses `compile*` or `compile*FromDS` depending on what the user specifies on the CLI.

Proposed behavior:
- ufo2glyphs (`to_glyphs`):
  - When reading a Designspace file, honor only the old glyph lib key and the Designspace-level lib key
  - When reading loose UFOs, construct a Designspace and read the UFO-level `public.skipExportGlyphs` lib key, but error out when the lists don't match or some have one and others don't
- glyphs2ufo (`to_ufos`, `to_designspace`)
  - Write UFO and Designspace-level `public.skipExportGlyphs` lib keys.